### PR TITLE
Define MonadState TLSSt's state function.

### DIFF
--- a/Network/TLS/State.hs
+++ b/Network/TLS/State.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleContexts, MultiParamTypeClasses, ExistentialQuantification, RankNTypes #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleContexts, MultiParamTypeClasses, ExistentialQuantification, RankNTypes, CPP #-}
 -- |
 -- Module      : Network.TLS.State
 -- License     : BSD-style
@@ -125,7 +125,9 @@ instance Functor TLSSt where
 instance MonadState TLSState TLSSt where
 	put x = TLSSt (lift $ put x)
 	get   = TLSSt (lift get)
+#if MIN_VERSION_mtl(2,1,0)
 	state f = TLSSt (lift $ state f)
+#endif
 
 runTLSState :: TLSSt a -> TLSState -> (Either TLSError a, TLSState)
 runTLSState f st = runState (runErrorT (runTLSSt f)) st


### PR DESCRIPTION
For some reason that I still don't know, when using state's
default definition with libraries

```
     base-4.5.0.0-40b99d05fae6a4eea95ea69e6e0c9702
     bytestring-0.9.2.1-18f26186028d7c0e92e78edc9071d376
     cereal-0.3.5.1-c85af6bc266354ac7b256440db39e874
     certificate-1.2.1-c61f160cdafc328081aeb08858403878
     crypto-api-0.10.1-a0c00402b73cec065108abe95d6cfaf2
     cryptocipher-0.3.0-d1785d4907a85f72ffd670491df324f2
     cryptohash-0.7.4-f6e253339d77757de756f81f77755b35
     mtl-2.1-e90c46af21f3870cee46f6218510d29d
```

I get <<loop>> for anything that uses the 'modify' function
(which in turn is defined in terms of 'state').  In particular, I
get it for 'startHandshakeClient' which is used in the beginning
by all tls clients.  For example,

  $ tls-simpleclient graph.facebook.com 443
  tls-simpleclient: <<loop>>

This commit fixes this bug.

(This is a harmless commit in the sense that even if I don't know
why this bug was happenning, it doesn't hurt to have an explicit
definition of 'state' -- it may actually save a few nanoseconds
here and there.)
