### PR TITLE
Fix build for GHC 7.6

### DIFF
--- a/Network/TLS/Context.hs
+++ b/Network/TLS/Context.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS.Context
 -- License     : BSD-style
@@ -49,7 +50,6 @@ import Network.TLS.Compression
 import Network.TLS.Crypto
 import Network.TLS.State
 import Network.TLS.Measurement
-import Data.Maybe
 import Data.Certificate.X509
 import Data.List (intercalate)
 import qualified Data.ByteString as B
@@ -59,7 +59,10 @@ import Control.Monad.State
 import Control.Exception (throwIO, Exception())
 import Data.IORef
 import System.IO (Handle, hSetBuffering, BufferMode(..), hFlush)
+
+#if !MIN_VERSION_base(4,6,0)
 import Prelude hiding (catch)
+#endif
 
 data TLSLogging = TLSLogging
 	{ loggingPacketSent :: String -> IO ()

--- a/Network/TLS/Core.hs
+++ b/Network/TLS/Core.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK hide #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 -- |
 -- Module      : Network.TLS.Core
@@ -54,7 +55,9 @@ import Control.Monad.State
 import Control.Exception (throwIO, Exception(), fromException, catch, SomeException)
 import System.IO (Handle)
 import System.IO.Error (mkIOError, eofErrorType)
+#if !MIN_VERSION_base(4,6,0)
 import Prelude hiding (catch)
+#endif
 
 data HandshakeFailed = HandshakeFailed TLSError
 	deriving (Show,Eq,Typeable)


### PR DESCRIPTION
In base 4.6, Prelude no longer exports 'catch'.

Also, removed a redundant "import Data.Maybe" in TLS.Context .
This does not break the build on GHC 7.0.3 and 7.4.2 .
