### PR TITLE
Added FlexibleContexts flag required by ghc-7.9

### DIFF
--- a/core/Network/TLS/Receiving.hs
+++ b/core/Network/TLS/Receiving.hs
@@ -8,6 +8,8 @@
 -- the Receiving module contains calls related to unmarshalling packets according
 -- to the TLS state
 --
+{-# LANGUAGE FlexibleContexts #-}
+
 module Network.TLS.Receiving
     ( processPacket
     ) where

--- a/core/Network/TLS/Record/Disengage.hs
+++ b/core/Network/TLS/Record/Disengage.hs
@@ -8,6 +8,8 @@
 -- Disengage a record from the Record layer.
 -- The record is decrypted, checked for integrity and then decompressed.
 --
+{-# LANGUAGE FlexibleContexts #-}
+
 module Network.TLS.Record.Disengage
         ( disengageRecord
         ) where


### PR DESCRIPTION
Your library didn't not compile under ghc-7.9 without FlexibleContexts flag. I added it.
