### PR TITLE
Supporting AEAD (AES 128 GCM).

### DIFF
--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -213,7 +213,8 @@ computeKeyBlock hst masterSecret ver cc = (pendingTx, pendingRx)
         keyblockSize = cipherKeyBlockSize cipher
 
         bulk         = cipherBulk cipher
-        digestSize   = hashSize $ cipherHash cipher
+        digestSize   = if hasMAC (bulkF bulk) then hashSize (cipherHash cipher)
+                                              else 0
         keySize      = bulkKeySize bulk
         ivSize       = bulkIVSize bulk
         kb           = generateKeyBlock ver (hstClientRandom hst)

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -13,6 +13,7 @@ module Network.TLS.Record.State
     , MacState(..)
     , RecordState(..)
     , newRecordState
+    , incrRecordState
     , RecordM
     , runRecordM
     , getRecordVersion

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -72,7 +72,9 @@ prepareRecord ctx f = do
     txState <- readMVar $ ctxTxState ctx
     let sz = case stCipher $ txState of
                   Nothing     -> 0
-                  Just cipher -> bulkIVSize $ cipherBulk cipher
+                  Just cipher -> if hasRecordIV $ bulkF $ cipherBulk cipher
+                                    then bulkIVSize $ cipherBulk cipher
+                                    else 0 -- to not generate IV
     if hasExplicitBlockIV ver && sz > 0
         then do newIV <- getStateRNG ctx sz
                 runTxState ctx (modify (setRecordIV newIV) >> f)

--- a/core/Network/TLS/Wire.hs
+++ b/core/Network/TLS/Wire.hs
@@ -43,6 +43,7 @@ module Network.TLS.Wire
     , putOpaque24
     , putInteger16
     , encodeWord16
+    , encodeWord32
     , encodeWord64
     ) where
 
@@ -131,6 +132,9 @@ putWords8 l = do
 putWord16 :: Word16 -> Put
 putWord16 = putWord16be
 
+putWord32 :: Word32 -> Put
+putWord32 = putWord32be
+
 putWords16 :: [Word16] -> Put
 putWords16 l = do
     putWord16 $ 2 * (fromIntegral $ length l)
@@ -160,6 +164,9 @@ putInteger16 = putOpaque16 . i2osp
 
 encodeWord16 :: Word16 -> Bytes
 encodeWord16 = runPut . putWord16
+
+encodeWord32 :: Word32 -> Bytes
+encodeWord32 = runPut . putWord32
 
 encodeWord64 :: Word64 -> Bytes
 encodeWord64 = runPut . putWord64be


### PR DESCRIPTION
This is an initial implementation of TLS 1.2's AEAD. Currently, only AES 128 GCM is supported. Inter-operability has been tested both with OpenSSL and Chrome Nightly.

I need to discuss the code of "FIXME" with @vincenthz. Since the current code does not store fixed_iv_length and record_iv_length separately, I had to hard-code the parameters: https://github.com/kazu-yamamoto/hs-tls/blob/aead/core/Network/TLS/Record/Disengage.hs#L119

Please review the patch and give me comments.
