### PR TITLE
Require mtl-2.2.1 or newer

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -56,6 +56,7 @@ import qualified Network.TLS.State as S
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as L
+import           Control.Monad (unless, when)
 import qualified Control.Exception as E
 
 import Control.Monad.State.Strict

--- a/core/Network/TLS/ErrT.hs
+++ b/core/Network/TLS/ErrT.hs
@@ -10,20 +10,12 @@
 module Network.TLS.ErrT
     ( runErrT
     , ErrT
-    , Error(..)
     , MonadError(..)
     ) where
 
-#if MIN_VERSION_mtl(2,2,1)
-import Control.Monad.Except
-import Control.Monad.Error.Class (Error(..))
+import Control.Monad.Except (MonadError(..))
+import Control.Monad.Trans.Except (ExceptT, runExceptT)
+
 runErrT :: ExceptT e m a -> m (Either e a)
 runErrT = runExceptT
 type ErrT = ExceptT
-#else
-import Control.Monad.Error
-runErrT :: ErrorT e m a -> m (Either e a)
-runErrT = runErrorT
-type ErrT = ErrorT
-#endif
-

--- a/core/Network/TLS/Handshake/Certificate.hs
+++ b/core/Network/TLS/Handshake/Certificate.hs
@@ -16,6 +16,7 @@ module Network.TLS.Handshake.Certificate
 import Network.TLS.Context.Internal
 import Network.TLS.Struct
 import Network.TLS.X509
+import Control.Monad (unless)
 import Control.Monad.State.Strict
 import Control.Exception (SomeException)
 import Data.X509 (ExtKeyUsage(..), ExtKeyUsageFlag, extensionGet)

--- a/core/Network/TLS/Handshake/State.hs
+++ b/core/Network/TLS/Handshake/State.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS.Handshake.State
 -- License     : BSD-style
@@ -190,9 +189,7 @@ newtype HandshakeM a = HandshakeM { runHandshakeM :: State HandshakeState a }
 instance MonadState HandshakeState HandshakeM where
     put x = HandshakeM (put x)
     get   = HandshakeM get
-#if MIN_VERSION_mtl(2,1,0)
     state f = HandshakeM (state f)
-#endif
 
 -- create a new empty handshake state
 newEmptyHandshake :: Version -> ClientRandom -> HandshakeState

--- a/core/Network/TLS/Record/State.hs
+++ b/core/Network/TLS/Record/State.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Network.TLS.Record.State
 -- License     : BSD-style
@@ -112,9 +111,7 @@ getRecordVersion = recordVersion <$> getRecordOptions
 instance MonadState RecordState RecordM where
     put x = RecordM $ \_  _  -> Right ((), x)
     get   = RecordM $ \_  st -> Right (st, st)
-#if MIN_VERSION_mtl(2,1,0)
     state f = RecordM $ \_ st -> Right (f st)
-#endif
 
 instance MonadError TLSError RecordM where
     throwError e   = RecordM $ \_ _ -> Left e

--- a/core/Network/TLS/State.hs
+++ b/core/Network/TLS/State.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -108,9 +107,7 @@ newtype TLSSt a = TLSSt { runTLSSt :: ErrT TLSError (State TLSState) a }
 instance MonadState TLSState TLSSt where
     put x = TLSSt (lift $ put x)
     get   = TLSSt (lift get)
-#if MIN_VERSION_mtl(2,1,0)
     state f = TLSSt (lift $ state f)
-#endif
 
 runTLSState :: TLSSt a -> TLSState -> (Either TLSError a, TLSState)
 runTLSState f st = runState (runErrT (runTLSSt f)) st

--- a/core/Network/TLS/Struct.hs
+++ b/core/Network/TLS/Struct.hs
@@ -9,7 +9,6 @@
 --
 -- the Struct module contains all definitions and values of the TLS protocol
 --
-{-# LANGUAGE CPP #-}
 module Network.TLS.Struct
     ( Version(..)
     , ConnectionEnd(..)
@@ -67,10 +66,6 @@ import Network.TLS.Types
 import Network.TLS.Crypto
 import Network.TLS.Util.Serialization
 import Network.TLS.Imports
-#if MIN_VERSION_mtl(2,2,1)
-#else
-import Control.Monad.Error
-#endif
 
 data ConnectionEnd = ConnectionServer | ConnectionClient
 data CipherType = CipherStream | CipherBlock | CipherAEAD
@@ -172,13 +167,6 @@ data TLSError =
     | Error_Packet_unexpected String String
     | Error_Packet_Parsing String
     deriving (Eq, Show, Typeable)
-
-#if MIN_VERSION_mtl(2,2,1)
-#else
-instance Error TLSError where
-    noMsg  = Error_Misc ""
-    strMsg = Error_Misc
-#endif
 
 instance Exception TLSError
 

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -42,7 +42,7 @@ Flag hans
 Library
   Default-Language:  Haskell2010
   Build-Depends:     base >= 4.9 && < 5
-                   , mtl >= 2
+                   , mtl >= 2.2.1
                    , transformers
                    , cereal >= 0.5.3
                    , bytestring


### PR DESCRIPTION
Depends on haskell-tls/hs-certificate/pull/130

Tested with 

     cabal test --constraint='mtl<2.2.2' all -w ghc-8.6.5

and 

    cabal test --constraint='mtl>=2.3' all -w ghc-9.2.2