### PR TITLE
TLSv1.3 UserCanceled Event

### DIFF
--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -147,7 +147,8 @@ recvData13 :: Context -> IO B.ByteString
 recvData13 ctx = do
     pkt <- recvPacket13 ctx
     either (onError terminate) process pkt
-  where process (Alert13 [(AlertLevel_Warning, CloseNotify)]) = tryBye ctx >> setEOF ctx >> return B.empty
+  where process (Alert13 [(AlertLevel_Warning, UserCanceled)]) = return B.empty
+        process (Alert13 [(AlertLevel_Warning, CloseNotify)]) = tryBye ctx >> setEOF ctx >> return B.empty
         process (Alert13 [(AlertLevel_Fatal, desc)]) = do
             setEOF ctx
             E.throwIO (Terminated True ("received fatal error: " ++ show desc) (Error_Protocol ("remote side fatal error", True, desc)))


### PR DESCRIPTION
The TLSv1.3 closure event message `user_canceled` is unhandled, which will currently throw an exception as it will fall through to the "unexpected message" function clause here: https://github.com/haskell-tls/hs-tls/blob/ad16bdd849e594a8a429857dccefcd725a4d0d45/core/Network/TLS/Core.hs#LL186C1-L187C1

>    user_canceled:  This alert notifies the recipient that the sender is
      canceling the handshake for some reason unrelated to a protocol
      failure.  If a user cancels an operation after the handshake is
      complete, just closing the connection by sending a "close_notify"
      is more appropriate.  This alert SHOULD be followed by a
      "close_notify".  This alert generally has AlertLevel=warning.

https://datatracker.ietf.org/doc/html/rfc8446#page-87

The spec reads as this message is informational and so I have left the handling code as a no-operation, just consuming the event. Perhaps a better approach would be to permit the user to override this.