### PR TITLE
Remove Exception instance for TLSError, bump to 1.8.0

### DIFF
--- a/core/Network/TLS.hs
+++ b/core/Network/TLS.hs
@@ -31,6 +31,9 @@ module Network.TLS
     , recvData
     , bye
 
+    -- * Exceptions
+    -- $exceptions
+
     -- * Backend abstraction
     , HasBackend(..)
     , Backend(..)
@@ -198,3 +201,10 @@ type Bytes = B.ByteString
 --   both cases of full-negotiation and resumption.
 getClientCertificateChain :: Context -> IO (Maybe CertificateChain)
 getClientCertificateChain ctx = usingState_ ctx S.getClientCertificateChain
+
+{- $exceptions
+    Since 1.8.0, this library only throws exceptions of type 'TLSException'.
+    In the common case where the chosen backend is socket, 'IOException'
+    may be thrown as well. This happens because the backend for sockets,
+    opaque to most modules in the @tls@ library, throws those exceptions.
+-}

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -234,7 +234,7 @@ withLog :: Context -> (Logging -> IO ()) -> IO ()
 withLog ctx f = ctxWithHooks ctx (f . hookLogging)
 
 throwCore :: MonadIO m => TLSError -> m a
-throwCore = liftIO . throwIO
+throwCore = liftIO . throwIO . Uncontextualized
 
 failOnEitherError :: MonadIO m => m (Either TLSError a) -> m a
 failOnEitherError f = do
@@ -255,7 +255,7 @@ usingState_ ctx f = failOnEitherError $ usingState ctx f
 usingHState :: MonadIO m => Context -> HandshakeM a -> m a
 usingHState ctx f = liftIO $ modifyMVar (ctxHandshake ctx) $ \mst ->
     case mst of
-        Nothing -> throwCore $ Error_Misc "missing handshake"
+        Nothing -> liftIO $ throwIO $ MissingHandshake
         Just st -> return $ swap (Just <$> runHandshake st f)
 
 getHState :: MonadIO m => Context -> m (Maybe HandshakeState)

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -26,7 +26,6 @@ import Control.Monad.Reader
 import Control.Monad.State.Strict
 import qualified Data.ByteString as B
 import Data.IORef
-import System.IO.Error (mkIOError, eofErrorType)
 
 import Network.TLS.Context.Internal
 import Network.TLS.Hooks
@@ -172,7 +171,7 @@ checkValid ctx = do
     established <- ctxEstablished ctx
     when (established == NotEstablished) $ throwIO ConnectionNotEstablished
     eofed <- ctxEOF ctx
-    when eofed $ throwIO $ mkIOError eofErrorType "data" Nothing Nothing
+    when eofed $ throwIO $ PostHandshake Error_EOF
 
 ----------------------------------------------------------------
 

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               tls
-version:            1.7.0
+version:            1.8.0
 license:            BSD3
 license-file:       LICENSE
 copyright:          Vincent Hanquez <vincent@snarc.org>


### PR DESCRIPTION
Stop throwing TLSError and IOException to make it the exceptions thrown by this library more predicatable.

Resolves https://github.com/haskell-tls/hs-tls/issues/456