### PR TITLE
Importing Extra.Cipher is not necessary anymore

### DIFF
--- a/tls/Network/TLS/Extra/Cipher.hs
+++ b/tls/Network/TLS/Extra/Cipher.hs
@@ -196,30 +196,12 @@ sortDeterministic = concatMap f
 -- hardware-acceleration support.  If this dynamic runtime behavior is not
 -- desired, use 'ciphersuite_default_det' instead.
 ciphersuite_default :: [Cipher]
-ciphersuite_default = sortOptimized sets_default
+ciphersuite_default = ciphersuite_strong
 
 -- | Same as 'ciphersuite_default', but using deterministic preference not
 -- influenced by the CPU.
 ciphersuite_default_det :: [Cipher]
-ciphersuite_default_det = sortDeterministic sets_default
-
-sets_default :: [CipherSet]
-sets_default =
-    [ -- First the PFS + GCM + SHA2 ciphers
-      SetAead
-        [cipher_ECDHE_ECDSA_AES128GCM_SHA256, cipher_ECDHE_ECDSA_AES256GCM_SHA384]
-        [cipher_ECDHE_ECDSA_CHACHA20POLY1305_SHA256]
-        [cipher_ECDHE_ECDSA_AES128CCM_SHA256, cipher_ECDHE_ECDSA_AES256CCM_SHA256]
-    , SetAead
-        [cipher_ECDHE_RSA_AES128GCM_SHA256, cipher_ECDHE_RSA_AES256GCM_SHA384]
-        [cipher_ECDHE_RSA_CHACHA20POLY1305_SHA256]
-        []
-    , -- TLS13 (listed at the end but version is negotiated first)
-      SetAead
-        [cipher_TLS13_AES128GCM_SHA256, cipher_TLS13_AES256GCM_SHA384]
-        [cipher_TLS13_CHACHA20POLY1305_SHA256]
-        [cipher_TLS13_AES128CCM_SHA256]
-    ]
+ciphersuite_default_det = ciphersuite_strong_det
 
 ----------------------------------------------------------------
 

--- a/tls/Network/TLS/Parameters.hs
+++ b/tls/Network/TLS/Parameters.hs
@@ -28,6 +28,7 @@ import Network.TLS.Compression
 import Network.TLS.Credentials
 import Network.TLS.Crypto
 import Network.TLS.Extension
+import Network.TLS.Extra.Cipher
 import Network.TLS.Imports
 import Network.TLS.Measurement
 import Network.TLS.RNG (Seed)
@@ -331,7 +332,7 @@ defaultSupported :: Supported
 defaultSupported =
     Supported
         { supportedVersions = [TLS13, TLS12]
-        , supportedCiphers = []
+        , supportedCiphers = ciphersuite_default
         , supportedCompressions = [nullCompression]
         , supportedHashSignatures = Struct.supportedSignatureSchemes
         , supportedSecureRenegotiation = True

--- a/tls/util/tls-client.hs
+++ b/tls/util/tls-client.hs
@@ -12,7 +12,6 @@ import Data.X509.CertificateStore
 import Network.Run.TCP
 import Network.Socket
 import Network.TLS
-import Network.TLS.Extra.Cipher
 import System.Console.GetOpt
 import System.Environment
 import System.Exit
@@ -293,8 +292,7 @@ getClientParams vers serverName port groups sm mstore keyLog =
             }
     supported =
         def
-            { supportedCiphers = ciphersuite_strong
-            , supportedVersions = vers
+            { supportedVersions = vers
             , supportedGroups = groups
             }
     hooks =

--- a/tls/util/tls-server.hs
+++ b/tls/util/tls-server.hs
@@ -10,7 +10,6 @@ import Data.IORef
 import qualified Data.Map.Strict as M
 import Network.Run.TCP
 import Network.TLS
-import Network.TLS.Extra.Cipher
 import System.Console.GetOpt
 import System.Environment (getArgs)
 import System.Exit
@@ -133,8 +132,7 @@ getServerParams creds sm keyLog =
             }
     supported =
         def
-            { supportedCiphers = ciphersuite_strong
-            , supportedGroups = [X25519, X448, P256, P521]
+            { supportedGroups = [X25519, X448, P256, P521]
             }
     hooks = def{onALPNClientSuggest = Just chooseALPN}
     debug = def{debugKeyLogger = keyLog}


### PR DESCRIPTION
- setting supportedCiphers to ciphersuite_default
- ciphersuite_default is now the same as ciphersuite_strong

See https://github.com/kazu-yamamoto/crypton-connection/pull/3