### PR TITLE
defining onServerFinished

### DIFF
--- a/tls/Network/TLS/Context/Internal.hs
+++ b/tls/Network/TLS/Context/Internal.hs
@@ -80,7 +80,6 @@ import Data.Tuple
 
 import Network.TLS.Backend
 import Network.TLS.Cipher
-import Network.TLS.Compression (Compression)
 import Network.TLS.Crypto
 import Network.TLS.Extension
 import Network.TLS.Handshake.Control
@@ -97,24 +96,9 @@ import Network.TLS.Struct13
 import Network.TLS.Types
 import Network.TLS.Util
 
--- | Information related to a running context, e.g. current cipher
-data Information = Information
-    { infoVersion :: Version
-    , infoCipher :: Cipher
-    , infoCompression :: Compression
-    , infoMainSecret :: Maybe ByteString
-    , infoExtendedMainSecret :: Bool
-    , infoClientRandom :: Maybe ClientRandom
-    , infoServerRandom :: Maybe ServerRandom
-    , infoSupportedGroup :: Maybe Group
-    , infoTLS12Resumption :: Bool
-    , infoTLS13HandshakeMode :: Maybe HandshakeMode13
-    , infoIsEarlyDataAccepted :: Bool
-    }
-    deriving (Show, Eq)
-
 -- | A TLS Context keep tls specific state, parameters and backend information.
-data Context = forall a.
+data Context
+    = forall a.
       Monoid a =>
     Context
     { ctxBackend :: Backend

--- a/tls/Network/TLS/Handshake/Client.hs
+++ b/tls/Network/TLS/Handshake/Client.hs
@@ -94,7 +94,7 @@ handshake cparams ctx groups mparams = do
                 | otherwise -> do
                     recvServerFirstFlight12 cparams ctx hss
                     sendClientSecondFlight12 cparams ctx
-                    recvServerSecondFlight12 ctx
+                    recvServerSecondFlight12 cparams ctx
   where
     groupToSend = listToMaybe groups
 

--- a/tls/Network/TLS/Handshake/Client/TLS12.hs
+++ b/tls/Network/TLS/Handshake/Client/TLS12.hs
@@ -79,8 +79,8 @@ sendClientSecondFlight12 cparams ctx = do
             sendClientCCC cparams ctx
             sendCCSandFinished ctx ClientRole
 
-recvServerSecondFlight12 :: Context -> IO ()
-recvServerSecondFlight12 ctx = do
+recvServerSecondFlight12 :: ClientParams -> Context -> IO ()
+recvServerSecondFlight12 cparams ctx = do
     sessionResuming <- usingState_ ctx isSessionResuming
     unless sessionResuming $ recvNSTandCCSandFinished ctx
     mticket <- usingState_ ctx getTLS12SessionTicket
@@ -98,6 +98,11 @@ recvServerSecondFlight12 ctx = do
             identity
             (fromJust sessionData)
     handshakeDone12 ctx
+    liftIO $ do
+        minfo <- contextGetInformation ctx
+        case minfo of
+            Nothing -> return ()
+            Just info -> onServerFinished (clientHooks cparams) info
 
 recvNSTandCCSandFinished :: Context -> IO ()
 recvNSTandCCSandFinished ctx = do

--- a/tls/util/tls-client.hs
+++ b/tls/util/tls-client.hs
@@ -298,6 +298,7 @@ getClientParams vers serverName port groups sm mstore keyLog =
     hooks =
         def
             { onSuggestALPN = return $ Just ["http/1.1"]
+            , onServerFinished = print
             }
     validateCache
         | isJust mstore = def


### PR DESCRIPTION
To obtain a handshake mode, `contextGetInformation` cab be used if `Context` is available.
But `Context` is not always available.
A good example is `http2-tls`.
So, this patch add a hook called `onServerFinished` which enables to get `Information` for clients when its connection is established.