### PR TITLE
Multiple PSKs

### DIFF
--- a/tls-session-manager/tls-session-manager.cabal
+++ b/tls-session-manager/tls-session-manager.cabal
@@ -29,7 +29,7 @@ library
         memory >= 0.18.0 && < 0.19,
         psqueues >= 0.2 && < 0.3,
         serialise >= 0.2 && < 0.3,
-        tls >= 2.0 && < 2.1
+        tls >= 2.0 && < 2.2
 
     if impl(ghc >=8)
         default-extensions: Strict StrictData

--- a/tls/Network/TLS/Context.hs
+++ b/tls/Network/TLS/Context.hs
@@ -266,7 +266,7 @@ getTLSExporter ctx = do
 
 exporter :: Context -> ByteString -> ByteString -> Int -> IO (Maybe ByteString)
 exporter ctx label context outlen = do
-    msecret <- usingState_ ctx getExporterSecret
+    msecret <- usingState_ ctx getTLS13ExporterSecret
     mcipher <- failOnEitherError $ runRxRecordState ctx $ gets stCipher
     return $ case (msecret, mcipher) of
         (Just secret, Just cipher) ->

--- a/tls/Network/TLS/Context/Internal.hs
+++ b/tls/Network/TLS/Context/Internal.hs
@@ -184,6 +184,7 @@ data TLS13State = TLS13State
     , tls13stClientExtensions :: [ExtensionRaw] -- client
     , tls13stChoice :: ~CipherChoice -- client
     , tls13stHsKey :: Maybe (SecretTriple HandshakeSecret) -- client
+    -- Actuall session id for TLS 1.2, random value for TLS 1.3
     , tls13stSession :: Session
     , tls13stSentExtensions :: [ExtensionID]
     }

--- a/tls/Network/TLS/Context/Internal.hs
+++ b/tls/Network/TLS/Context/Internal.hs
@@ -286,7 +286,7 @@ contextGetInformation ctx = do
     let accepted = case hstate of
             Just st -> hstTLS13RTT0Status st == RTT0Accepted
             Nothing -> False
-    tls12resumption <- usingState_ ctx isTLS12SessionResuming
+    tls12resumption <- usingState_ ctx getTLS12SessionResuming
     case (ver, cipher) of
         (Just v, Just c) ->
             return $

--- a/tls/Network/TLS/Context/Internal.hs
+++ b/tls/Network/TLS/Context/Internal.hs
@@ -290,7 +290,19 @@ contextGetInformation ctx = do
         (Just v, Just c) ->
             return $
                 Just $
-                    Information v c comp ms ems cr sr grp tls12resumption hm13 accepted
+                    Information
+                        { infoVersion = v
+                        , infoCipher = c
+                        , infoCompression = comp
+                        , infoMainSecret = ms
+                        , infoExtendedMainSecret = ems
+                        , infoClientRandom = cr
+                        , infoServerRandom = sr
+                        , infoSupportedGroup = grp
+                        , infoTLS12Resumption = tls12resumption
+                        , infoTLS13HandshakeMode = hm13
+                        , infoIsEarlyDataAccepted = accepted
+                        }
         _ -> return Nothing
 
 contextSend :: Context -> ByteString -> IO ()

--- a/tls/Network/TLS/Context/Internal.hs
+++ b/tls/Network/TLS/Context/Internal.hs
@@ -286,7 +286,7 @@ contextGetInformation ctx = do
     let accepted = case hstate of
             Just st -> hstTLS13RTT0Status st == RTT0Accepted
             Nothing -> False
-    tls12resumption <- usingState_ ctx isSessionResuming
+    tls12resumption <- usingState_ ctx isTLS12SessionResuming
     case (ver, cipher) of
         (Just v, Just c) ->
             return $

--- a/tls/Network/TLS/Core.hs
+++ b/tls/Network/TLS/Core.hs
@@ -298,7 +298,7 @@ recvData13 ctx = do
     loopHandshake13 [] = return ()
     -- fixme: some implementations send multiple NST at the same time.
     -- Only the first one is used at this moment.
-    loopHandshake13 (NewSessionTicket13 life add nonce label exts : hs) = do
+    loopHandshake13 (NewSessionTicket13 life add nonce ticket exts : hs) = do
         role <- usingState_ ctx S.getRole
         unless (role == ClientRole) $
             let reason = "Session ticket is allowed for client only"
@@ -318,8 +318,8 @@ recvData13 ctx = do
                 life7d = min life 604800 -- 7 days max
             tinfo <- createTLS13TicketInfo life7d (Right add) Nothing
             sdata <- getSessionData13 ctx usedCipher tinfo maxSize psk
-            let label' = B.copy label
-            void $ sessionEstablish (sharedSessionManager $ ctxShared ctx) label' sdata
+            let ticket' = B.copy ticket
+            void $ sessionEstablish (sharedSessionManager $ ctxShared ctx) ticket' sdata
             modifyTLS13State ctx $ \st -> st{tls13stRecvNST = True}
         loopHandshake13 hs
     loopHandshake13 (KeyUpdate13 mode : hs) = do
@@ -379,7 +379,7 @@ recvHS13 ctx breakLoop = do
     loopHandshake13 [] = return ()
     -- fixme: some implementations send multiple NST at the same time.
     -- Only the first one is used at this moment.
-    loopHandshake13 (NewSessionTicket13 life add nonce label exts : hs) = do
+    loopHandshake13 (NewSessionTicket13 life add nonce ticket exts : hs) = do
         role <- usingState_ ctx S.getRole
         unless (role == ClientRole) $
             let reason = "Session ticket is allowed for client only"
@@ -399,8 +399,8 @@ recvHS13 ctx breakLoop = do
                 life7d = min life 604800 -- 7 days max
             tinfo <- createTLS13TicketInfo life7d (Right add) Nothing
             sdata <- getSessionData13 ctx usedCipher tinfo maxSize psk
-            let label' = B.copy label
-            void $ sessionEstablish (sharedSessionManager $ ctxShared ctx) label' sdata
+            let ticket' = B.copy ticket
+            void $ sessionEstablish (sharedSessionManager $ ctxShared ctx) ticket' sdata
             modifyTLS13State ctx $ \st -> st{tls13stRecvNST = True}
         loopHandshake13 hs
     loopHandshake13 (h : hs) = do

--- a/tls/Network/TLS/Handshake/Client.hs
+++ b/tls/Network/TLS/Handshake/Client.hs
@@ -10,6 +10,7 @@ import Network.TLS.Context.Internal
 import Network.TLS.Crypto
 import Network.TLS.Extension
 import Network.TLS.Handshake.Client.ClientHello
+import Network.TLS.Handshake.Client.Common
 import Network.TLS.Handshake.Client.ServerHello
 import Network.TLS.Handshake.Client.TLS12
 import Network.TLS.Handshake.Client.TLS13
@@ -37,9 +38,9 @@ handshakeClientWith _ _ _ =
 -- values intertwined with response from the server.
 handshakeClient :: ClientParams -> Context -> IO ()
 handshakeClient cparams ctx = do
-    groups <- case clientWantSessionResume cparams of
-        Nothing -> return groupsSupported
-        Just (_, sdata) -> case sessionGroup sdata of
+    groups <- case clientSessions cparams of
+        [] -> return groupsSupported
+        (_, sdata) : _ -> case sessionGroup sdata of
             Nothing -> return [] -- TLS 1.2 or earlier
             Just grp
                 | grp `elem` groupsSupported -> return $ grp : filter (/= grp) groupsSupported

--- a/tls/Network/TLS/Handshake/Client/ClientHello.hs
+++ b/tls/Network/TLS/Handshake/Client/ClientHello.hs
@@ -51,6 +51,14 @@ sendClientHello cparams ctx groups mparams pskinfo = do
         return crand
     generateClientHelloParams Nothing = do
         crand <- clientRandom ctx
+        {-
+                let sessions
+                        | not (null (clientWantSessionResume2 cparams)) =
+                            clientWantSessionResume2 cparams
+                        | otherwise = case clientWantSessionResume cparams of
+                            Nothing -> []
+                            Just s -> [s]
+        -}
         let paramSession = case clientWantSessionResume cparams of
                 Nothing -> Session Nothing
                 Just (sidOrTkt, sdata)

--- a/tls/Network/TLS/Handshake/Client/Common.hs
+++ b/tls/Network/TLS/Handshake/Client/Common.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Network.TLS.Handshake.Client.Common (
     throwMiscErrorOnException,
@@ -9,6 +10,7 @@ module Network.TLS.Handshake.Client.Common (
     sigAlgsToCertTypes,
     setALPN,
     contextSync,
+    clientSessions,
 ) where
 
 import Control.Exception (SomeException)
@@ -348,3 +350,8 @@ setALPN ctx msgt exts = case extensionLookup EID_ApplicationLayerProtocolNegotia
 contextSync :: Context -> ClientState -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
     HandshakeSync sync _ -> sync ctx ctl
+
+clientSessions :: ClientParams -> [(SessionID, SessionData)]
+clientSessions ClientParams{..} = case clientWantSessionResume of
+    Nothing -> clientWantSessionResumeList
+    Just ent -> clientWantSessionResumeList ++ [ent]

--- a/tls/Network/TLS/Handshake/Client/ServerHello.hs
+++ b/tls/Network/TLS/Handshake/Client/ServerHello.hs
@@ -147,10 +147,10 @@ processServerHello cparams ctx (ServerHello rver serverRan serverSession cipher 
             usingState_ ctx $ setSession serverSession
             updateContext13 ctx cipherAlg
         else do
-            let resumingSession = case clientWantSessionResume cparams of
-                    Just (_, sessionData) ->
+            let resumingSession = case clientSessions cparams of
+                    (_, sessionData) : _ ->
                         if serverSession == clientSession then Just sessionData else Nothing
-                    Nothing -> Nothing
+                    _ -> Nothing
 
             usingState_ ctx $ do
                 setSession serverSession

--- a/tls/Network/TLS/Handshake/Client/ServerHello.hs
+++ b/tls/Network/TLS/Handshake/Client/ServerHello.hs
@@ -144,7 +144,7 @@ processServerHello cparams ctx (ServerHello rver serverRan serverSession cipher 
     if ver == TLS13
         then do
             -- xxx serverSession must be identity for PSK
-            usingState_ ctx $ setSession serverSession False
+            usingState_ ctx $ setSession serverSession
             updateContext13 ctx cipherAlg
         else do
             let resumingSession = case clientWantSessionResume cparams of
@@ -152,7 +152,9 @@ processServerHello cparams ctx (ServerHello rver serverRan serverSession cipher 
                         if serverSession == clientSession then Just sessionData else Nothing
                     Nothing -> Nothing
 
-            usingState_ ctx $ setSession serverSession (isJust resumingSession)
+            usingState_ ctx $ do
+                setSession serverSession
+                setTLS12SessionResuming $ isJust resumingSession
             updateContext12 ctx exts resumingSession
 processServerHello _ _ p = unexpected (show p) (Just "server hello")
 

--- a/tls/Network/TLS/Handshake/Client/ServerHello.hs
+++ b/tls/Network/TLS/Handshake/Client/ServerHello.hs
@@ -117,6 +117,7 @@ processServerHello cparams ctx (ServerHello rver serverRan serverSession cipher 
     let supportedVers = supportedVersions $ clientSupported cparams
 
     when (ver == TLS13) $ do
+        -- TLS 1.3 server MUST echo the session id
         when (clientSession /= serverSession) $
             throwCore $
                 Error_Protocol

--- a/tls/Network/TLS/Handshake/Client/ServerHello.hs
+++ b/tls/Network/TLS/Handshake/Client/ServerHello.hs
@@ -143,7 +143,7 @@ processServerHello cparams ctx (ServerHello rver serverRan serverSession cipher 
 
     if ver == TLS13
         then do
-            -- xxx serverSession must be identity for PSK
+            -- Session is dummy in TLS 1.3.
             usingState_ ctx $ setSession serverSession
             updateContext13 ctx cipherAlg
         else do

--- a/tls/Network/TLS/Handshake/Client/TLS12.hs
+++ b/tls/Network/TLS/Handshake/Client/TLS12.hs
@@ -34,7 +34,7 @@ import Network.TLS.X509 hiding (Certificate)
 
 recvServerFirstFlight12 :: ClientParams -> Context -> [Handshake] -> IO ()
 recvServerFirstFlight12 cparams ctx hs = do
-    resuming <- usingState_ ctx isSessionResuming
+    resuming <- usingState_ ctx isTLS12SessionResuming
     if resuming
         then recvNSTandCCSandFinished ctx
         else do
@@ -72,7 +72,7 @@ expectServerHelloDone _ p = unexpected (show p) (Just "server hello data")
 
 sendClientSecondFlight12 :: ClientParams -> Context -> IO ()
 sendClientSecondFlight12 cparams ctx = do
-    sessionResuming <- usingState_ ctx isSessionResuming
+    sessionResuming <- usingState_ ctx isTLS12SessionResuming
     if sessionResuming
         then sendCCSandFinished ctx ClientRole
         else do
@@ -81,7 +81,7 @@ sendClientSecondFlight12 cparams ctx = do
 
 recvServerSecondFlight12 :: ClientParams -> Context -> IO ()
 recvServerSecondFlight12 cparams ctx = do
-    sessionResuming <- usingState_ ctx isSessionResuming
+    sessionResuming <- usingState_ ctx isTLS12SessionResuming
     unless sessionResuming $ recvNSTandCCSandFinished ctx
     mticket <- usingState_ ctx getTLS12SessionTicket
     identity <- case mticket of

--- a/tls/Network/TLS/Handshake/Client/TLS12.hs
+++ b/tls/Network/TLS/Handshake/Client/TLS12.hs
@@ -34,7 +34,7 @@ import Network.TLS.X509 hiding (Certificate)
 
 recvServerFirstFlight12 :: ClientParams -> Context -> [Handshake] -> IO ()
 recvServerFirstFlight12 cparams ctx hs = do
-    resuming <- usingState_ ctx isTLS12SessionResuming
+    resuming <- usingState_ ctx getTLS12SessionResuming
     if resuming
         then recvNSTandCCSandFinished ctx
         else do
@@ -72,7 +72,7 @@ expectServerHelloDone _ p = unexpected (show p) (Just "server hello data")
 
 sendClientSecondFlight12 :: ClientParams -> Context -> IO ()
 sendClientSecondFlight12 cparams ctx = do
-    sessionResuming <- usingState_ ctx isTLS12SessionResuming
+    sessionResuming <- usingState_ ctx getTLS12SessionResuming
     if sessionResuming
         then sendCCSandFinished ctx ClientRole
         else do
@@ -81,7 +81,7 @@ sendClientSecondFlight12 cparams ctx = do
 
 recvServerSecondFlight12 :: ClientParams -> Context -> IO ()
 recvServerSecondFlight12 cparams ctx = do
-    sessionResuming <- usingState_ ctx isTLS12SessionResuming
+    sessionResuming <- usingState_ ctx getTLS12SessionResuming
     unless sessionResuming $ recvNSTandCCSandFinished ctx
     mticket <- usingState_ ctx getTLS12SessionTicket
     identity <- case mticket of

--- a/tls/Network/TLS/Handshake/Common13.hs
+++ b/tls/Network/TLS/Handshake/Common13.hs
@@ -217,12 +217,13 @@ makePSKBinder ctx (BaseSecret sec) usedHash truncLen mch = do
         totalLen = B.length x
         takeLen = totalLen - truncLen
 
-replacePSKBinder :: ByteString -> ByteString -> ByteString
-replacePSKBinder pskz binder = identities `B.append` binders
+replacePSKBinder :: ByteString -> [ByteString] -> ByteString
+replacePSKBinder pskz bds = tLidentities <> binders
   where
-    bindersSize = B.length binder + 3
-    identities = B.take (B.length pskz - bindersSize) pskz
-    binders = runPut $ putOpaque16 $ runPut $ putOpaque8 binder
+    tLidentities = B.take (B.length pskz - B.length binders) pskz
+    -- See instance Extension PreSharedKey
+    binders = runPut $ putOpaque16 $ runPut (mapM_ putBinder bds)
+    putBinder = putOpaque8
 
 ----------------------------------------------------------------
 

--- a/tls/Network/TLS/Handshake/Common13.hs
+++ b/tls/Network/TLS/Handshake/Common13.hs
@@ -531,7 +531,7 @@ calculateApplicationSecret ctx choice (BaseSecret sec) hChSf = do
     let clientApplicationSecret0 = deriveSecret usedHash applicationSecret "c ap traffic" hChSf
         serverApplicationSecret0 = deriveSecret usedHash applicationSecret "s ap traffic" hChSf
         exporterSecret = deriveSecret usedHash applicationSecret "exp master" hChSf
-    usingState_ ctx $ setExporterSecret exporterSecret
+    usingState_ ctx $ setTLS13ExporterSecret exporterSecret
     let sts0 =
             ServerTrafficSecret serverApplicationSecret0
                 :: ServerTrafficSecret ApplicationSecret

--- a/tls/Network/TLS/Handshake/Server.hs
+++ b/tls/Network/TLS/Handshake/Server.hs
@@ -80,7 +80,7 @@ newCertReqContext ctx = getStateRNG ctx 32
 requestCertificateServer :: ServerParams -> Context -> IO Bool
 requestCertificateServer sparams ctx = do
     tls13 <- tls13orLater ctx
-    supportsPHA <- usingState_ ctx getClientSupportsPHA
+    supportsPHA <- usingState_ ctx getTLS13ClientSupportsPHA
     let ok = tls13 && supportsPHA
     when ok $ do
         certReqCtx <- newCertReqContext ctx

--- a/tls/Network/TLS/Handshake/Server/ServerHello12.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello12.hs
@@ -229,7 +229,7 @@ makeServerHello
     -> Session
     -> IO Handshake
 makeServerHello sparams ctx usedCipher mcred chExts session = do
-    resuming <- usingState_ ctx isTLS12SessionResuming
+    resuming <- usingState_ ctx getTLS12SessionResuming
     srand <-
         serverRandom ctx TLS12 $ supportedVersions $ serverSupported sparams
     case mcred of

--- a/tls/Network/TLS/Handshake/Server/ServerHello12.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello12.hs
@@ -229,7 +229,7 @@ makeServerHello
     -> Session
     -> IO Handshake
 makeServerHello sparams ctx usedCipher mcred chExts session = do
-    resuming <- usingState_ ctx isSessionResuming
+    resuming <- usingState_ ctx isTLS12SessionResuming
     srand <-
         serverRandom ctx TLS12 $ supportedVersions $ serverSupported sparams
     case mcred of

--- a/tls/Network/TLS/Handshake/Server/ServerHello12.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello12.hs
@@ -38,7 +38,7 @@ sendServerHello12 sparams ctx (usedCipher, mcred) ch@CH{..} = do
     case resumeSessionData of
         Nothing -> do
             serverSession <- newSession ctx
-            usingState_ ctx $ setSession serverSession False
+            usingState_ ctx $ setSession serverSession
             serverhello <-
                 makeServerHello sparams ctx usedCipher mcred chExtensions serverSession
             build <- sendServerFirstFlight sparams ctx usedCipher mcred chExtensions
@@ -46,7 +46,9 @@ sendServerHello12 sparams ctx (usedCipher, mcred) ch@CH{..} = do
             sendPacket12 ctx $ Handshake ff
             contextFlush ctx
         Just sessionData -> do
-            usingState_ ctx $ setSession chSession True
+            usingState_ ctx $ do
+                setSession chSession
+                setTLS12SessionResuming True
             serverhello <-
                 makeServerHello sparams ctx usedCipher mcred chExtensions chSession
             sendPacket12 ctx $ Handshake [serverhello]

--- a/tls/Network/TLS/Handshake/Server/ServerHello13.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello13.hs
@@ -46,7 +46,7 @@ sendServerHello13
         )
 sendServerHello13 sparams ctx clientKeyShare (usedCipher, usedHash, rtt0) CH{..} = do
     newSession ctx >>= \ss -> usingState_ ctx $ do
-        setSession ss False
+        setSession ss
         setClientSupportsPHA supportsPHA
     usingHState ctx $ setSupportedGroup $ keyShareEntryGroup clientKeyShare
     srand <- setServerParameter

--- a/tls/Network/TLS/Handshake/Server/ServerHello13.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello13.hs
@@ -47,7 +47,7 @@ sendServerHello13
 sendServerHello13 sparams ctx clientKeyShare (usedCipher, usedHash, rtt0) CH{..} = do
     newSession ctx >>= \ss -> usingState_ ctx $ do
         setSession ss
-        setClientSupportsPHA supportsPHA
+        setTLS13ClientSupportsPHA supportsPHA
     usingHState ctx $ setSupportedGroup $ keyShareEntryGroup clientKeyShare
     srand <- setServerParameter
     -- ALPN is used in choosePSK

--- a/tls/Network/TLS/Handshake/Server/ServerHello13.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello13.hs
@@ -141,7 +141,7 @@ sendServerHello13 sparams ctx clientKeyShare (usedCipher, usedHash, rtt0) CH{..}
 
     choosePSK = case extensionLookup EID_PreSharedKey chExtensions
         >>= extensionDecode MsgTClientHello of
-        Just (PreSharedKeyClientHello (PskIdentity sessionId obfAge : _) bnds@(bnd : _)) -> do
+        Just (PreSharedKeyClientHello (PskIdentity identity obfAge : _) bnds@(bnd : _)) -> do
             when (null dhModes) $
                 throwCore $
                     Error_Protocol "no psk_key_exchange_modes extension" MissingExtension
@@ -149,10 +149,11 @@ sendServerHello13 sparams ctx clientKeyShare (usedCipher, usedHash, rtt0) CH{..}
                 then do
                     let len = sum (map (\x -> B.length x + 1) bnds) + 2
                         mgr = sharedSessionManager $ serverShared sparams
+                    -- xxx -- invalidate session data
                     msdata <-
                         if rtt0
-                            then sessionResumeOnlyOnce mgr sessionId
-                            else sessionResume mgr sessionId
+                            then sessionResumeOnlyOnce mgr identity
+                            else sessionResume mgr identity
                     case msdata of
                         Just sdata -> do
                             let tinfo = fromJust $ sessionTicketInfo sdata

--- a/tls/Network/TLS/Handshake/Server/ServerHello13.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello13.hs
@@ -149,7 +149,9 @@ sendServerHello13 sparams ctx clientKeyShare (usedCipher, usedHash, rtt0) CH{..}
                 then do
                     let len = sum (map (\x -> B.length x + 1) bnds) + 2
                         mgr = sharedSessionManager $ serverShared sparams
-                    -- xxx -- invalidate session data
+                    -- sessionInvalidate is not used for TLS 1.3
+                    -- because PSK is always changed.
+                    -- So, identity is not stored in Context.
                     msdata <-
                         if rtt0
                             then sessionResumeOnlyOnce mgr identity

--- a/tls/Network/TLS/Handshake/Server/TLS12.hs
+++ b/tls/Network/TLS/Handshake/Server/TLS12.hs
@@ -60,6 +60,11 @@ sessionEstablished ctx = do
         Session (Just sessionId) -> do
             sessionData <- getSessionData ctx
             let sessionId' = B.copy sessionId
+            -- SessionID method: SessionID is used as key to store
+            -- SessionData. Nothing is returned.
+            --
+            -- Session ticket method: SessionID is ignored. SessionData
+            -- is encrypted and returned.
             sessionEstablish
                 (sharedSessionManager $ ctxShared ctx)
                 sessionId'

--- a/tls/Network/TLS/Handshake/State.hs
+++ b/tls/Network/TLS/Handshake/State.hs
@@ -131,7 +131,7 @@ data HandshakeState = HandshakeState
     , hstSupportedGroup :: Maybe Group
     , hstTLS13HandshakeMode :: HandshakeMode13
     , hstTLS13RTT0Status :: RTT0Status
-    , hstTLS13EarlySecret :: Maybe (BaseSecret EarlySecret)
+    , hstTLS13EarlySecret :: Maybe (BaseSecret EarlySecret) -- xxx
     , hstTLS13ResumptionSecret :: Maybe (BaseSecret ResumptionSecret)
     , hstCCS13Sent :: Bool
     }

--- a/tls/Network/TLS/Parameters.hs
+++ b/tls/Network/TLS/Parameters.hs
@@ -105,6 +105,10 @@ data ClientParams = ClientParams
     -- ^ try to establish a connection using this session.
     --
     -- Default: 'Nothing'
+    , clientWantSessionResume2 :: [(SessionID, SessionData)]
+    -- ^ try to establish a connection using one of this sessions.
+    --
+    -- Default: '[]'
     , clientShared :: Shared
     -- ^ See the default value of 'Shared'.
     , clientHooks :: ClientHooks
@@ -133,6 +137,7 @@ defaultParamsClient serverName serverId =
         , clientServerIdentification = (serverName, serverId)
         , clientUseServerNameIndication = True
         , clientWantSessionResume = Nothing
+        , clientWantSessionResume2 = []
         , clientShared = def
         , clientHooks = def
         , clientSupported = def

--- a/tls/Network/TLS/Parameters.hs
+++ b/tls/Network/TLS/Parameters.hs
@@ -107,8 +107,12 @@ data ClientParams = ClientParams
     -- Use 'clientWantSessionResume13' instead for TLS 1.3.
     --
     -- Default: 'Nothing'
-    , clientWantSessionResume13 :: [(SessionID, SessionData)]
-    -- ^ try to establish a connection using one of this sessions for TLS 1.3.
+    , clientWantSessionResumeList :: [(SessionID, SessionData)]
+    -- ^ try to establish a connection using one of this sessions
+    -- especially for TLS 1.3.
+    -- This take precedence over 'clientWantSessionResume'.
+    -- For convenience, this can be specified for TLS 1.2 but only the first
+    -- entry is used.
     --
     -- Default: '[]'
     , clientShared :: Shared
@@ -139,7 +143,7 @@ defaultParamsClient serverName serverId =
         , clientServerIdentification = (serverName, serverId)
         , clientUseServerNameIndication = True
         , clientWantSessionResume = Nothing
-        , clientWantSessionResume13 = []
+        , clientWantSessionResumeList = []
         , clientShared = def
         , clientHooks = def
         , clientSupported = def

--- a/tls/Network/TLS/Parameters.hs
+++ b/tls/Network/TLS/Parameters.hs
@@ -102,11 +102,13 @@ data ClientParams = ClientParams
     --
     -- Default: 'True'
     , clientWantSessionResume :: Maybe (SessionID, SessionData)
-    -- ^ try to establish a connection using this session.
+    -- ^ try to establish a connection using this session for TLS 1.2/TLS 1.3.
+    -- This can be used for TLS 1.3 but for backward compatibility purpose only.
+    -- Use 'clientWantSessionResume13' instead for TLS 1.3.
     --
     -- Default: 'Nothing'
-    , clientWantSessionResume2 :: [(SessionID, SessionData)]
-    -- ^ try to establish a connection using one of this sessions.
+    , clientWantSessionResume13 :: [(SessionID, SessionData)]
+    -- ^ try to establish a connection using one of this sessions for TLS 1.3.
     --
     -- Default: '[]'
     , clientShared :: Shared
@@ -137,7 +139,7 @@ defaultParamsClient serverName serverId =
         , clientServerIdentification = (serverName, serverId)
         , clientUseServerNameIndication = True
         , clientWantSessionResume = Nothing
-        , clientWantSessionResume2 = []
+        , clientWantSessionResume13 = []
         , clientShared = def
         , clientHooks = def
         , clientSupported = def

--- a/tls/Network/TLS/Session.hs
+++ b/tls/Network/TLS/Session.hs
@@ -14,9 +14,9 @@ data SessionManager = SessionManager
     , sessionResumeOnlyOnce :: SessionIDorTicket -> IO (Maybe SessionData)
     -- ^ Used for 0RTT on TLS 1.3 servers to lookup 'SessionData' with 'SessionID' or to decrypt 'Ticket' to get 'SessionData'.
     , sessionEstablish :: SessionIDorTicket -> SessionData -> IO (Maybe Ticket)
-    -- ^ Used TLS 1.2\/1.3 servers\/clients to store 'SessionData' with 'SessionID' or to encrypt 'SessionData' to get 'Ticket'. In the client side, 'Nothing' should be returned. For clients, only this field should be set with 'noSessionManager'.
+    -- ^ Used on TLS 1.2\/1.3 servers to store 'SessionData' with 'SessionID' or to encrypt 'SessionData' to get 'Ticket' ignoring 'SessionID'. Used on TLS 1.2\/1.3 clients to store 'SessionData' with 'SessionIDorTicket' and then return 'Nothing'. For clients, only this field should be set with 'noSessionManager'.
     , sessionInvalidate :: SessionIDorTicket -> IO ()
-    -- ^ Used TLS 1.2\/1.3 servers to delete 'SessionData' with 'SessionID' on errors.
+    -- ^ Used TLS 1.2 servers to delete 'SessionData' with 'SessionID' on errors.
     , sessionUseTicket :: Bool
     -- ^ Used on TLS 1.2 servers to decide to use 'SessionID' or 'Ticket'. Note that 'SessionID' and 'Ticket' are integrated as identity in TLS 1.3.
     }

--- a/tls/Network/TLS/Session.hs
+++ b/tls/Network/TLS/Session.hs
@@ -5,18 +5,20 @@ module Network.TLS.Session (
 
 import Network.TLS.Types
 
--- | A session manager
+-- | A session manager.
+-- In the server side, all fields are used.
+-- In the client side, only 'sessionEstablish' is used.
 data SessionManager = SessionManager
     { sessionResume :: SessionIDorTicket -> IO (Maybe SessionData)
     -- ^ Used on TLS 1.2\/1.3 servers to lookup 'SessionData' with 'SessionID' or to decrypt 'Ticket' to get 'SessionData'.
     , sessionResumeOnlyOnce :: SessionIDorTicket -> IO (Maybe SessionData)
     -- ^ Used for 0RTT on TLS 1.3 servers to lookup 'SessionData' with 'SessionID' or to decrypt 'Ticket' to get 'SessionData'.
-    , sessionEstablish :: SessionID -> SessionData -> IO (Maybe Ticket)
+    , sessionEstablish :: SessionIDorTicket -> SessionData -> IO (Maybe Ticket)
     -- ^ Used TLS 1.2\/1.3 servers\/clients to store 'SessionData' with 'SessionID' or to encrypt 'SessionData' to get 'Ticket'. In the client side, 'Nothing' should be returned. For clients, only this field should be set with 'noSessionManager'.
-    , sessionInvalidate :: SessionID -> IO ()
-    -- ^ Used TLS 1.2\/1.3 servers to delete 'SessionData' with 'SessionID' if @sessionUseTicket@ is 'True'.
+    , sessionInvalidate :: SessionIDorTicket -> IO ()
+    -- ^ Used TLS 1.2\/1.3 servers to delete 'SessionData' with 'SessionID' on errors.
     , sessionUseTicket :: Bool
-    -- ^ Used on TLS 1.2 servers to decide to use 'SessionID' or 'Ticket'. Note that TLS 1.3 servers always use session tickets.
+    -- ^ Used on TLS 1.2 servers to decide to use 'SessionID' or 'Ticket'. Note that 'SessionID' and 'Ticket' are integrated as identity in TLS 1.3.
     }
 
 -- | The session manager to do nothing.

--- a/tls/Network/TLS/State.hs
+++ b/tls/Network/TLS/State.hs
@@ -302,11 +302,14 @@ getPeerVerifyData = do
 
 getFirstVerifyData :: TLSSt (Maybe ByteString)
 getFirstVerifyData = do
-    -- xxx TLS 1.2 vs 1.3
-    resuming <- getTLS12SessionResuming
-    if resuming
-        then gets stServerVerifyData
-        else gets stClientVerifyData
+    ver <- getVersion
+    case ver of
+        TLS13 -> gets stServerVerifyData
+        _ -> do
+            resuming <- getTLS12SessionResuming
+            if resuming
+                then gets stServerVerifyData
+                else gets stClientVerifyData
 
 getRole :: TLSSt Role
 getRole = gets stClientContext

--- a/tls/Network/TLS/State.hs
+++ b/tls/Network/TLS/State.hs
@@ -83,7 +83,6 @@ import Network.TLS.Wire (GetContinuation)
 
 data TLSState = TLSState
     { stSession :: Session
-    , stTLS12SessionTicket :: Maybe Ticket
     , -- RFC 5746, Renegotiation Indication Extension
       -- RFC 5929, Channel Bindings for TLS, "tls-unique"
       stSecureRenegotiation :: Bool
@@ -105,6 +104,7 @@ data TLSState = TLSState
     , stVersion :: Maybe Version
     , --
       stTLS12SessionResuming :: Bool
+    , stTLS12SessionTicket :: Maybe Ticket
     , --
       stTLS13KeyShare :: Maybe KeyShare
     , stTLS13PreSharedKey :: Maybe PreSharedKey
@@ -129,7 +129,6 @@ newTLSState :: StateRNG -> Role -> TLSState
 newTLSState rng clientContext =
     TLSState
         { stSession = Session Nothing
-        , stTLS12SessionTicket = Nothing
         , stSecureRenegotiation = False
         , stClientVerifyData = Nothing
         , stServerVerifyData = Nothing
@@ -147,6 +146,7 @@ newTLSState rng clientContext =
         , stClientContext = clientContext
         , stVersion = Nothing
         , stTLS12SessionResuming = False
+        , stTLS12SessionTicket = Nothing
         , stTLS13KeyShare = Nothing
         , stTLS13PreSharedKey = Nothing
         , stTLS13HRR = False

--- a/tls/Network/TLS/State.hs
+++ b/tls/Network/TLS/State.hs
@@ -198,8 +198,8 @@ certVerifyHandshakeTypeMaterial _ = False
 certVerifyHandshakeMaterial :: Handshake -> Bool
 certVerifyHandshakeMaterial = certVerifyHandshakeTypeMaterial . typeOfHandshake
 
-setSession :: Session -> Bool -> TLSSt ()
-setSession session resuming = modify (\st -> st{stSession = session, stTLS12SessionResuming = resuming})
+setSession :: Session -> TLSSt ()
+setSession session = modify (\st -> st{stSession = session})
 
 getSession :: TLSSt Session
 getSession = gets stSession

--- a/tls/Network/TLS/State.hs
+++ b/tls/Network/TLS/State.hs
@@ -44,7 +44,8 @@ module Network.TLS.State (
     setServerCertificateChain,
     setSession,
     getSession,
-    isTLS12SessionResuming,
+    setTLS12SessionResuming,
+    getTLS12SessionResuming,
     getRole,
     setExporterSecret,
     getExporterSecret,
@@ -203,8 +204,11 @@ setSession session resuming = modify (\st -> st{stSession = session, stTLS12Sess
 getSession :: TLSSt Session
 getSession = gets stSession
 
-isTLS12SessionResuming :: TLSSt Bool
-isTLS12SessionResuming = gets stTLS12SessionResuming
+setTLS12SessionResuming :: Bool -> TLSSt ()
+setTLS12SessionResuming b = modify (\st -> st{stTLS12SessionResuming = b})
+
+getTLS12SessionResuming :: TLSSt Bool
+getTLS12SessionResuming = gets stTLS12SessionResuming
 
 setVersion :: Version -> TLSSt ()
 setVersion ver = modify (\st -> st{stVersion = Just ver})
@@ -295,7 +299,7 @@ getPeerVerifyData = do
 getFirstVerifyData :: TLSSt (Maybe ByteString)
 getFirstVerifyData = do
     -- xxx TLS 1.2 vs 1.3
-    resuming <- isTLS12SessionResuming
+    resuming <- getTLS12SessionResuming
     if resuming
         then gets stServerVerifyData
         else gets stClientVerifyData

--- a/tls/tls.cabal
+++ b/tls/tls.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               tls
-version:            2.0.6
+version:            2.1.0
 license:            BSD3
 license-file:       LICENSE
 copyright:          Vincent Hanquez <vincent@snarc.org>

--- a/tls/tls.cabal
+++ b/tls/tls.cabal
@@ -180,6 +180,7 @@ executable tls-server
     build-depends:
         base >=4.9 && <5,
         bytestring,
+        base16-bytestring,
         containers,
         crypton,
         crypton-x509-store,

--- a/tls/tls.cabal
+++ b/tls/tls.cabal
@@ -209,6 +209,7 @@ executable tls-client
     ghc-options:        -Wall -threaded -rtsopts
     build-depends:
         base >=4.9 && <5,
+        base16-bytestring,
         bytestring,
         crypton,
         crypton-x509-store,

--- a/tls/util/Client.hs
+++ b/tls/util/Client.hs
@@ -18,7 +18,7 @@ data Aux = Aux
     , auxPort :: ServiceName
     , auxDebug :: String -> IO ()
     , auxShow :: ByteString -> IO ()
-    , auxReadResumptionData :: IO (Maybe (SessionID, SessionData))
+    , auxReadResumptionData :: IO [(SessionID, SessionData)]
     }
 
 type Cli = Aux -> [ByteString] -> Context -> IO ()

--- a/tls/util/Client.hs
+++ b/tls/util/Client.hs
@@ -4,7 +4,8 @@
 module Client (
     Aux (..),
     Cli,
-    client,
+    clientHTTP11,
+    clientDNS,
 ) where
 
 import qualified Data.ByteString.Lazy.Char8 as CL8
@@ -23,8 +24,8 @@ data Aux = Aux
 
 type Cli = Aux -> [ByteString] -> Context -> IO ()
 
-client :: Cli
-client Aux{..} paths ctx = do
+clientHTTP11 :: Cli
+clientHTTP11 aux@Aux{..} paths ctx = do
     sendData ctx $
         "GET "
             <> CL8.fromStrict (head paths)
@@ -34,11 +35,19 @@ client Aux{..} paths ctx = do
             <> "\r\n"
             <> "Connection: close\r\n"
             <> "\r\n"
-    loop
-    auxShow "\n"
+    consume ctx aux
+
+clientDNS aux paths ctx = do
+    sendData
+        ctx
+        "\x00\x2c\xdc\xe3\x01\x00\x00\x01\x00\x00\x00\x00\x00\x01\x03\x77\x77\x77\x07\x65\x78\x61\x6d\x70\x6c\x65\x03\x63\x6f\x6d\x00\x00\x01\x00\x01\x00\x00\x29\x04\xd0\x00\x00\x00\x00\x00\x00"
+    consume ctx aux
+
+consume :: Context -> Aux -> IO ()
+consume ctx Aux{..} = loop
   where
     loop = do
         bs <- recvData ctx
-        when (bs /= "") $ do
-            auxShow bs
-            loop
+        if bs == ""
+            then auxShow "\n"
+            else auxShow bs >> loop

--- a/tls/util/Client.hs
+++ b/tls/util/Client.hs
@@ -8,6 +8,7 @@ module Client (
     clientDNS,
 ) where
 
+import qualified Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Lazy.Char8 as CL8
 import Network.Socket
 import Network.TLS
@@ -37,11 +38,14 @@ clientHTTP11 aux@Aux{..} paths ctx = do
             <> "\r\n"
     consume ctx aux
 
-clientDNS aux paths ctx = do
+clientDNS :: Cli
+clientDNS Aux{..} _paths ctx = do
     sendData
         ctx
         "\x00\x2c\xdc\xe3\x01\x00\x00\x01\x00\x00\x00\x00\x00\x01\x03\x77\x77\x77\x07\x65\x78\x61\x6d\x70\x6c\x65\x03\x63\x6f\x6d\x00\x00\x01\x00\x01\x00\x00\x29\x04\xd0\x00\x00\x00\x00\x00\x00"
-    consume ctx aux
+    bs <- recvData ctx
+    auxShow $ "Reply: " <> BS16.encode bs
+    auxShow "\n"
 
 consume :: Context -> Aux -> IO ()
 consume ctx Aux{..} = loop

--- a/tls/util/tls-client.hs
+++ b/tls/util/tls-client.hs
@@ -269,7 +269,7 @@ modifyClientParams cparams [] _ = cparams
 modifyClientParams cparams ts@(ticket : _) early
     | sessionVersion (snd ticket) == TLS13 =
         cparams
-            { clientWantSessionResume2 = ts
+            { clientWantSessionResume13 = ts
             , clientUseEarlyData = early
             }
     | otherwise = cparams{clientWantSessionResume = Just ticket}

--- a/tls/util/tls-client.hs
+++ b/tls/util/tls-client.hs
@@ -265,14 +265,11 @@ runTLS cparams Aux{..} action =
 
 modifyClientParams
     :: ClientParams -> [(SessionID, SessionData)] -> Bool -> ClientParams
-modifyClientParams cparams [] _ = cparams
-modifyClientParams cparams ts@(ticket : _) early
-    | sessionVersion (snd ticket) == TLS13 =
-        cparams
-            { clientWantSessionResume13 = ts
-            , clientUseEarlyData = early
-            }
-    | otherwise = cparams{clientWantSessionResume = Just ticket}
+modifyClientParams cparams ts early =
+    cparams
+        { clientWantSessionResumeList = ts
+        , clientUseEarlyData = early
+        }
 
 getClientParams
     :: Options

--- a/tls/util/tls-server.hs
+++ b/tls/util/tls-server.hs
@@ -5,6 +5,8 @@
 
 module Main where
 
+import qualified Data.ByteString.Base16 as BS16
+import qualified Data.ByteString.Char8 as C8
 import Data.Default.Class (def)
 import Data.IORef
 import qualified Data.Map.Strict as M
@@ -152,9 +154,17 @@ newSessionManager = do
     ref <- newIORef M.empty
     return $
         noSessionManager
-            { sessionResume = \key -> M.lookup key <$> readIORef ref
-            , sessionResumeOnlyOnce = \key -> M.lookup key <$> readIORef ref
-            , sessionEstablish = \key val -> atomicModifyIORef' ref $ \m -> (M.insert key val m, Nothing)
-            , sessionInvalidate = \key -> atomicModifyIORef' ref $ \m -> (M.delete key m, ())
+            { sessionResume = \key -> do
+                C8.putStrLn $ "sessionResume: " <> BS16.encode key
+                M.lookup key <$> readIORef ref
+            , sessionResumeOnlyOnce = \key -> do
+                C8.putStrLn $ "sessionResumeOnlyOnce: " <> BS16.encode key
+                M.lookup key <$> readIORef ref
+            , sessionEstablish = \key val -> do
+                C8.putStrLn $ "sessionEstablish: " <> BS16.encode key
+                atomicModifyIORef' ref $ \m -> (M.insert key val m, Nothing)
+            , sessionInvalidate = \key -> do
+                C8.putStrLn $ "sessionEstablish: " <> BS16.encode key
+                atomicModifyIORef' ref $ \m -> (M.delete key m, ())
             , sessionUseTicket = False
             }


### PR DESCRIPTION
1.1.1.1 and 8.8.8.8 provide multiple NewSessionTickets.
To resume a session, clients need to specify multiple tickets.
Since these tickets are obtained in the previous session, `SessionData` is unique.
So, binders for tickets are identical.