### PR TITLE
Fix #482 Elaborate change log entry for tls-2.1.0

### DIFF
--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -6,7 +6,9 @@
 ## Version 2.1.0
 
 * Breaking change: stop exporting constructors to maintain future
-  compatibilities. Use `def` and `noSessionManager` instead.
+  compatibilities. Field names are still exported, and values can be updated
+  with them using record syntax. Use `def` and `noSessionManager` as initial
+  values.
 * `onServerFinished` is added to `ClientHooks`.
 * `clientWantSessionResumeList` is added to `ClientParams` to support
   multiple tickets for TLS 1.3.


### PR DESCRIPTION
See:
* #482 

The motivation for this pull request is that the Haskell 2010 Language Report is slient-ish on the ability to update values with record syntax when the data constructor is not exported but the field name is exported. See https://discourse.haskell.org/t/updating-values-with-record-syntax-when-data-constructor-is-not-exported/10603/8