### PR TITLE
Fix wrong version in change log

### DIFF
--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 2.2.1
+## Version 2.1.1
 
 * `bye` directly calls `timeout recvHS13`, not spawning a thread for
   `timeout recvHS13`. So, `bye` can receive an exception if thrown.


### PR DESCRIPTION
`tls-2.1.1` was released on Hackage with the change log referring to version 2.2.1.