### PR TITLE
Export defaultSupported (renamed to tlsDefaultSupported)

### DIFF
--- a/tls/Network/TLS.hs
+++ b/tls/Network/TLS.hs
@@ -99,6 +99,7 @@ module Network.TLS (
 
     -- ** Supported
     Supported,
+    tlsDefaultSupported,
     supportedVersions,
     supportedCiphers,
     supportedCompressions,

--- a/tls/Network/TLS/Parameters.hs
+++ b/tls/Network/TLS/Parameters.hs
@@ -12,6 +12,7 @@ module Network.TLS.Parameters (
 
     -- * special default
     defaultParamsClient,
+    tlsDefaultSupported,
 
     -- * Parameters
     MaxFragmentEnum (..),
@@ -341,8 +342,11 @@ data EMSMode
       RequireEMS
     deriving (Show, Eq)
 
-defaultSupported :: Supported
-defaultSupported =
+-- | Default values for Supported
+--
+-- This is same value as given by the 'Default' instance
+tlsDefaultSupported :: Supported
+tlsDefaultSupported =
     Supported
         { supportedVersions = [TLS13, TLS12]
         , supportedCiphers = ciphersuite_default
@@ -358,7 +362,7 @@ defaultSupported =
         }
 
 instance Default Supported where
-    def = defaultSupported
+    def = tlsDefaultSupported
 
 -- | Parameters that are common to clients and servers.
 data Shared = Shared


### PR DESCRIPTION
Implementation of the suggestion here https://github.com/haskell-tls/hs-tls/pull/486#issuecomment-2438642189

Because `Network.TLS.Quic` already exports something called `defaultSupported`, I chose to come up with a new name to avoid confusion and also the possibility of a package upgrade causing ambiguity errors for people.

I don't feel strongly on what that name should be; went with `tlsDefaultSupported`