### PR TITLE
Fix SSL 2 version constant to 0x0002

### DIFF
--- a/tls/Network/TLS/Types/Version.hs
+++ b/tls/Network/TLS/Types/Version.hs
@@ -15,7 +15,7 @@ newtype Version = Version Word16 deriving (Eq, Ord, Generic)
 
 {- FOURMOLU_DISABLE -}
 pattern SSL2  :: Version
-pattern SSL2   = Version 0x0200
+pattern SSL2   = Version 0x0002
 pattern SSL3  :: Version
 pattern SSL3   = Version 0x0300
 pattern TLS10 :: Version


### PR DESCRIPTION
SSL 2 uses a version field of 0x0002, not 0x0200.  This is confirmed not only in the original Netscape spec [1] and RFC draft of the time [2], but also in major implementations such as OpenSSL [3] and Wireshark [4].

[1] https://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html
[2] https://datatracker.ietf.org/doc/html/draft-hickman-netscape-ssl-00
[3] https://github.com/openssl/openssl/blob/OpenSSL_0_9_6m/ssl/ssl2.h#L66-L71
[4] https://github.com/wireshark/wireshark/blob/release-4.4/epan/dissectors/packet-tls-utils.h#L266-L277