### PR TITLE
Don't contain early_data if serverEarlyDataSize is 0.

### DIFF
--- a/tls/Network/TLS/Handshake/Server/TLS13.hs
+++ b/tls/Network/TLS/Handshake/Server/TLS13.hs
@@ -168,8 +168,11 @@ sendNewSessionTicket sparams ctx usedCipher exts applicationSecret sfSentTime = 
     createNewSessionTicket life add nonce identity maxSize =
         NewSessionTicket13 life add nonce identity nstExtensions
       where
-        earlyDataExt = toExtensionRaw $ EarlyDataIndication $ Just $ fromIntegral maxSize
-        nstExtensions = [earlyDataExt]
+        nstExtensions
+            | maxSize == 0 = []
+            | otherwise = [earlyDataExt]
+          where
+            earlyDataExt = toExtensionRaw $ EarlyDataIndication $ Just $ fromIntegral maxSize
     adjustLifetime i
         | i < 0 = 0
         | i > 604800 = 604800


### PR DESCRIPTION
This should fix https://github.com/kazu-yamamoto/quic/issues/85