### PR TITLE
support P384 and P521 curves

### DIFF
--- a/tls/Network/TLS/Crypto.hs
+++ b/tls/Network/TLS/Crypto.hs
@@ -433,6 +433,8 @@ kxSupportedPrivKeyEC :: PrivKeyEC -> Bool
 kxSupportedPrivKeyEC privkey =
     case ecPrivKeyCurveName privkey of
         Just ECC.SEC_p256r1 -> True
+        Just ECC.SEC_p384r1 -> True
+        Just ECC.SEC_p521r1 -> True
         _ -> False
 
 -- Perform a public-key operation with a parameterized ECC implementation when
@@ -453,6 +455,10 @@ withPubKeyEC pubkey withProxy withClassic whenUnknown =
         Nothing -> Just whenUnknown
         Just ECC.SEC_p256r1 ->
             maybeCryptoError $ withProxy p256 <$> ECDSA.decodePublic p256 bs
+        Just ECC.SEC_p384r1 ->
+            maybeCryptoError $ withProxy p384 <$> ECDSA.decodePublic p384 bs
+        Just ECC.SEC_p521r1 ->
+            maybeCryptoError $ withProxy p521 <$> ECDSA.decodePublic p521 bs
         Just curveName ->
             let curve = ECC.getCurveByName curveName
                 pub = unserializePoint curve pt
@@ -482,9 +488,17 @@ withPrivKeyEC privkey withProxy withUnsupported whenUnknown =
             -- using ECDSA.decodePrivate, unfortunately the data type chosen in
             -- x509 was Integer.
             maybeCryptoError $ withProxy p256 <$> ECDSA.scalarFromInteger p256 d
+        Just ECC.SEC_p384r1 ->
+            maybeCryptoError $ withProxy p384 <$> ECDSA.scalarFromInteger p384 d
+        Just ECC.SEC_p521r1 ->
+            maybeCryptoError $ withProxy p521 <$> ECDSA.scalarFromInteger p521 d
         Just curveName -> Just $ withUnsupported curveName
   where
     d = privkeyEC_priv privkey
 
 p256 :: Proxy ECDSA.Curve_P256R1
 p256 = Proxy
+p384 :: Proxy ECDSA.Curve_P384R1
+p384 = Proxy
+p521 :: Proxy ECDSA.Curve_P521R1
+p521 = Proxy

--- a/tls/test/Arbitrary.hs
+++ b/tls/test/Arbitrary.hs
@@ -407,7 +407,7 @@ arbitraryPairParamsWithVersionsAndCiphers (clientVersions, serverVersions) (clie
     return (clientState, serverState)
 
 arbitraryClientCredential :: Version -> Gen Credential
-arbitraryClientCredential _ = arbitraryCredentialsOfEachType' >>= elements
+arbitraryClientCredential _ = arbitraryCredentialsOfEachCurve' >>= elements
 
 arbitraryRSACredentialWithUsage
     :: [ExtKeyUsageFlag] -> Gen (CertificateChain, PrivKey)

--- a/tls/test/PubKey.hs
+++ b/tls/test/PubKey.hs
@@ -91,6 +91,7 @@ knownECCurves :: [ECC.CurveName]
 knownECCurves =
     [ ECC.SEC_p256r1
     , ECC.SEC_p384r1
+    , ECC.SEC_p521r1
     ]
 
 defaultECCurve :: ECC.CurveName


### PR DESCRIPTION
currently, a certificate generated with p384 curve key is not usable with hs-tls.

```
openssl ecparam -out ec_key.pem -name secp384r1 -genkey
openssl req -new -key ec_key.pem -x509 -nodes -days 3650 -out ec_cert.pem
```

the server using hs-tls shows 'credential not found' message.

```
% ./dist-newstyle/build/x86_64-linux/ghc-9.6.7/tls-debug-0.4.8/x/tls-simpleserver/build/tls-simpleserver/tls-simpleserver -d -v --key ./ec_key.pem --certificate ./ec_cert.pem  4433

connection from 127.0.0.1:59262
debug: << Handshake [ClientHello (CH {chVersion = TLS1.2, chRandom = ClientRandom "b9928e6a7a414497d22acf44a9091cb783fd13691d91b73707f33379e74ac9e1", chSession = Session "9be672a956ddc3ada2e187984e83c8870bed292b0ffbe4ddaed222316b600680", chCiphers = [0xC02C,0xC0AD,0xCCA9,0xC02B,0xC0AC,0xC030,0xCCA8,0xC02F,0x1302,0x1303,0x1301,0x1304,0xC0AE,0xC0AF,0x1305], chComps = [0], chExtensions = [ServerName ["127.0.0.1"],SupportedGroups [X25519,X448,P256,FFDHE2048,FFDHE3072,FFDHE4096,P384,FFDHE6144,FFDHE8192,P521],EcPointFormatsSupported [EcPointFormat_Uncompressed],SignatureAlgorithms [(TLS13,Ed448),(TLS13,Ed25519),(SHA512,ECDSA),(SHA384,ECDSA),(SHA256,ECDSA),(TLS13,RSApssRSAeSHA512),(TLS13,RSApssRSAeSHA384),(TLS13,RSApssRSAeSHA256),(TLS13,RSApsspssSHA512),(TLS13,RSApsspssSHA384),(TLS13,RSApsspssSHA256),(SHA512,RSA),(SHA384,RSA),(SHA256,RSA),(SHA1,RSA),(SHA1,ECDSA)],ExtendedMainSecret,CompressCertificate [zlib],SessionTicket "",Versions [TLS1.3,TLS1.2],PskKeyExchangeModes [PSK_DHE_KE],PostHandshakeAuth,KeyShare [X25519],SecureRenegotiation "00"]})]
debug: >> Alert13 [(AlertLevel_Fatal,HandshakeFailure)] tls-simpleserver: HandshakeFailed (Error_Protocol "credential not found" HandshakeFailure)
```

this commit adds a support for p384 and p521 curves with the limitation of not being able to generate in constant time.  it also changes a test case to cover the original issue of 'credential not found'.

probablly this relates to the closed issue #424.