### PR TITLE
A new architecture to calculate receiver's transcript hash with wire format

### DIFF
--- a/tls/Network/TLS/Context.hs
+++ b/tls/Network/TLS/Context.hs
@@ -112,7 +112,7 @@ class TLSParams a where
     getTLSCommonParams :: a -> CommonParams
     getTLSRole :: a -> Role
     doHandshake :: a -> Context -> IO ()
-    doHandshakeWith :: a -> Context -> Handshake -> IO ()
+    doHandshakeWith :: a -> Context -> HandshakeR -> IO ()
     doRequestCertificate :: a -> Context -> IO Bool
     doPostHandshakeAuthWith :: a -> Context -> Handshake13 -> IO ()
 

--- a/tls/Network/TLS/Context/Internal.hs
+++ b/tls/Network/TLS/Context/Internal.hs
@@ -166,7 +166,7 @@ data RecordLimit
 
 data RoleParams = RoleParams
     { doHandshake_ :: Context -> IO ()
-    , doHandshakeWith_ :: Context -> Handshake -> IO ()
+    , doHandshakeWith_ :: Context -> HandshakeR -> IO ()
     , doRequestCertificate_ :: Context -> IO Bool
     , doPostHandshakeAuthWith_ :: Context -> Handshake13 -> IO ()
     }
@@ -271,11 +271,13 @@ data Established
 
 data PendingRecvAction
     = -- | simple pending action. The first 'Bool' is necessity of alignment.
-      -- The second bool is update transcript hash.
-      PendingRecvAction Bool Bool (Handshake13 -> IO ())
+      PendingRecvAction Bool (Handshake13 -> IO ())
+    | PendingRecvActionSelfUpdate Bool (Handshake13R -> IO ())
     | -- | pending action taking transcript hash up to preceding message
       --   The first 'Bool' is necessity of alignment.
-      PendingRecvActionHash Bool (TranscriptHash -> Handshake13 -> IO ())
+      PendingRecvActionHash
+        Bool
+        (TranscriptHash -> Handshake13 -> IO ())
 
 updateMeasure :: Context -> (Measurement -> Measurement) -> IO ()
 updateMeasure ctx = modifyIORef' (ctxMeasurement ctx)

--- a/tls/Network/TLS/Crypto.hs
+++ b/tls/Network/TLS/Crypto.hs
@@ -7,6 +7,7 @@ module Network.TLS.Crypto (
     HashCtx,
     hashInit,
     hashUpdate,
+    hashUpdates,
     hashUpdateSSL,
     hashFinal,
     module Network.TLS.Crypto.DH,

--- a/tls/Network/TLS/Handshake.hs
+++ b/tls/Network/TLS/Handshake.hs
@@ -25,9 +25,9 @@ handshake_ ctx =
 -- This is called automatically by 'recvData', in a context where the read lock
 -- is already taken.  So contrary to 'handshake' above, here we only need to
 -- call withWriteLock.
-handshakeWith :: MonadIO m => Context -> Handshake -> m ()
-handshakeWith ctx hs =
+handshakeWith :: MonadIO m => Context -> HandshakeR -> m ()
+handshakeWith ctx hsr =
     liftIO $
         withWriteLock ctx $
             handleException ctx $
-                doHandshakeWith_ (ctxRoleParams ctx) ctx hs
+                doHandshakeWith_ (ctxRoleParams ctx) ctx hsr

--- a/tls/Network/TLS/Handshake/Client.hs
+++ b/tls/Network/TLS/Handshake/Client.hs
@@ -26,8 +26,9 @@ import Network.TLS.Struct
 
 ----------------------------------------------------------------
 
-handshakeClientWith :: ClientParams -> Context -> Handshake -> IO ()
-handshakeClientWith cparams ctx HelloRequest = handshakeClient cparams ctx
+handshakeClientWith
+    :: ClientParams -> Context -> HandshakeR -> IO ()
+handshakeClientWith cparams ctx (HelloRequest, _b) = handshakeClient cparams ctx -- xxx
 handshakeClientWith _ _ _ =
     throwCore $
         Error_Protocol
@@ -76,7 +77,7 @@ handshake cparams ctx groups mparams = do
     --------------------------------
     -- Receiving ServerHello
     unless async $ do
-        (ver, hss, hrr) <- receiveServerHello cparams ctx mparams
+        (ver, hbs, hrr) <- receiveServerHello cparams ctx mparams
         --------------------------------
         -- Switching to HRR, TLS 1.2 or TLS 1.3
         case ver of
@@ -93,7 +94,7 @@ handshake cparams ctx groups mparams = do
                             "server denied TLS 1.3 when connecting with early data"
                             HandshakeFailure
                 | otherwise -> do
-                    recvServerFirstFlight12 cparams ctx hss
+                    recvServerFirstFlight12 cparams ctx hbs
                     sendClientSecondFlight12 cparams ctx
                     recvServerSecondFlight12 cparams ctx
   where

--- a/tls/Network/TLS/Handshake/Server/ClientHello12.hs
+++ b/tls/Network/TLS/Handshake/Server/ClientHello12.hs
@@ -13,7 +13,6 @@ import Network.TLS.ErrT
 import Network.TLS.Extension
 import Network.TLS.Handshake.Server.Common
 import Network.TLS.Handshake.Signature
-import Network.TLS.IO.Encode
 import Network.TLS.Imports
 import Network.TLS.Parameters
 import Network.TLS.State
@@ -46,7 +45,6 @@ processClientHello12 sparams ctx ch = do
             Error_Protocol "no cipher in common with the TLS 1.2 client" HandshakeFailure
     let usedCipher = onCipherChoosing hooks TLS12 ciphersFilteredVersion
     mcred <- chooseCreds usedCipher creds signatureCreds
-    void $ updateTranscriptHash12 ctx $ ClientHello ch
     return (usedCipher, mcred)
 
 checkSecureRenegotiation :: Context -> ClientHello -> IO ()

--- a/tls/Network/TLS/Handshake/Server/ServerHello12.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello12.hs
@@ -42,7 +42,7 @@ sendServerHello12 sparams ctx (usedCipher, mcred) ch@CH{..} = do
             sh <- makeServerHello sparams ctx usedCipher mcred chExtensions serverSession
             build <- sendServerFirstFlight sparams ctx usedCipher mcred chExtensions
             let ff = ServerHello sh : build [ServerHelloDone]
-            sendPacket12 ctx $ Handshake ff
+            sendPacket12 ctx $ Handshake ff []
             contextFlush ctx
         Just sessionData -> do
             usingState_ ctx $ do
@@ -50,7 +50,7 @@ sendServerHello12 sparams ctx (usedCipher, mcred) ch@CH{..} = do
                 setTLS12SessionResuming True
             sh <-
                 makeServerHello sparams ctx usedCipher mcred chExtensions chSession
-            sendPacket12 ctx $ Handshake [ServerHello sh]
+            sendPacket12 ctx $ Handshake [ServerHello sh] []
             let mainSecret = sessionSecret sessionData
             usingHState ctx $ setMainSecret TLS12 ServerRole mainSecret
             logKey ctx $ MainSecret mainSecret

--- a/tls/Network/TLS/Handshake/Server/TLS12.hs
+++ b/tls/Network/TLS/Handshake/Server/TLS12.hs
@@ -40,7 +40,7 @@ recvClientSecondFlight12 sparams ctx resumeSessionData = do
                 Nothing -> return ()
                 Just ticket -> do
                     let life = adjustLifetime $ serverTicketLifetime sparams
-                    sendPacket12 ctx $ Handshake [NewSessionTicket life ticket]
+                    sendPacket12 ctx $ Handshake [NewSessionTicket life ticket] []
             sendCCSandFinished ctx ServerRole
         Just _ -> do
             _ <- sessionEstablished ctx

--- a/tls/Network/TLS/Handshake/State.hs
+++ b/tls/Network/TLS/Handshake/State.hs
@@ -104,7 +104,7 @@ data TransHashState
     = -- | Initial state
       TransHashState0
     | -- | A raw CH is stored since hash algo is not chosen yet.
-      TransHashState1 ByteString
+      TransHashState1 ([ByteString] -> [ByteString])
     | -- | Hashed
       TransHashState2 HashCtx
 
@@ -161,7 +161,7 @@ data HandshakeState = HandshakeState
     , hstCCS13Recv :: Bool
     , hstTLS13OuterClientRandom :: Maybe ClientRandom
     -- ^ Used for key logging in the case of ECH.
-    , hstTLS13ClientHello :: Maybe ClientHello
+    , hstTLS13ClientHello :: Maybe (ClientHello, [ByteString])
     -- ^ Inner client hello in the case of ECH.
     , hstTLS13ECHAccepted :: Bool
     , hstTLS13ECHEE :: Bool
@@ -403,11 +403,11 @@ getOuterClientRandom = gets hstTLS13OuterClientRandom
 setOuterClientRandom :: Maybe ClientRandom -> HandshakeM ()
 setOuterClientRandom mcr = modify' (\hst -> hst{hstTLS13OuterClientRandom = mcr})
 
-getClientHello :: HandshakeM (Maybe ClientHello)
+getClientHello :: HandshakeM (Maybe (ClientHello, [ByteString]))
 getClientHello = gets hstTLS13ClientHello
 
-setClientHello :: ClientHello -> HandshakeM ()
-setClientHello ch = modify' $ \hst -> hst{hstTLS13ClientHello = Just ch}
+setClientHello :: ClientHello -> [ByteString] -> HandshakeM ()
+setClientHello ch b = modify' $ \hst -> hst{hstTLS13ClientHello = Just (ch, b)}
 
 getECHAccepted :: HandshakeM Bool
 getECHAccepted = gets hstTLS13ECHAccepted

--- a/tls/Network/TLS/IO/Encode.hs
+++ b/tls/Network/TLS/IO/Encode.hs
@@ -2,7 +2,9 @@ module Network.TLS.IO.Encode (
     encodePacket12,
     encodePacket13,
     updateTranscriptHash12,
+    encodeUpdateTranscriptHash12,
     updateTranscriptHash13,
+    encodeUpdateTranscriptHash13,
 ) where
 
 import Control.Concurrent.MVar
@@ -47,8 +49,8 @@ encodePacket12 ctx recordLayer pkt = do
 -- packets are not fragmented here but by callers of sendPacket, so that the
 -- empty-packet countermeasure may be applied to each fragment independently.
 packetToFragments12 :: Context -> Maybe Int -> Packet -> IO [ByteString]
-packetToFragments12 ctx mlen (Handshake hss) =
-    getChunks mlen . B.concat <$> mapM (updateTranscriptHash12 ctx) hss
+packetToFragments12 ctx mlen (Handshake hss _) =
+    getChunks mlen . B.concat <$> mapM (encodeUpdateTranscriptHash12 ctx) hss
 packetToFragments12 _ _ (Alert a) = return [encodeAlerts a]
 packetToFragments12 _ _ ChangeCipherSpec = return [encodeChangeCipherSpec]
 packetToFragments12 _ _ (AppData x) = return [x]
@@ -73,16 +75,31 @@ switchTxEncryption ctx = do
   where
     isCBC tx = maybe False (\c -> bulkBlockSize (cipherBulk c) > 0) (stCipher tx)
 
-updateTranscriptHash12 :: Context -> Handshake -> IO ByteString
-updateTranscriptHash12 ctx hs = do
+encodeUpdateTranscriptHash12 :: Context -> Handshake -> IO ByteString
+encodeUpdateTranscriptHash12 ctx hs = do
     when (certVerifyHandshakeMaterial hs) $
         usingHState ctx $
             addHandshakeMessage encoded
     let label = show $ typeOfHandshake hs
     when (finishedHandshakeMaterial hs) $ updateTranscriptHash ctx label encoded
+    when (isClientHello hs) $ do
+        usingHState ctx $ do
+            (ch, b) <- fromJust <$> getClientHello
+            when (null b) $ setClientHello ch [encoded]
     return encoded
   where
     encoded = encodeHandshake hs
+    isClientHello (ClientHello _) = True
+    isClientHello _ = False
+
+updateTranscriptHash12 :: Context -> HandshakeR -> IO ()
+updateTranscriptHash12 ctx (hs, bss) = do
+    when (certVerifyHandshakeMaterial hs) $
+        usingHState ctx $
+            mapM_ addHandshakeMessage bss
+    let label = show $ typeOfHandshake hs
+    when (finishedHandshakeMaterial hs) $ do
+        mapM_ (updateTranscriptHash ctx label) bss
 
 ----------------------------------------------------------------
 
@@ -100,14 +117,14 @@ encodePacket13 ctx recordLayer pkt = do
     fmap mconcat <$> forEitherM records (recordEncode13 recordLayer ctx)
 
 packetToFragments13 :: Context -> Maybe Int -> Packet13 -> IO [ByteString]
-packetToFragments13 ctx mlen (Handshake13 hss) =
-    getChunks mlen . B.concat <$> mapM (updateTranscriptHash13 ctx) hss
+packetToFragments13 ctx mlen (Handshake13 hss _) =
+    getChunks mlen . B.concat <$> mapM (encodeUpdateTranscriptHash13 ctx) hss
 packetToFragments13 _ _ (Alert13 a) = return [encodeAlerts a]
 packetToFragments13 _ _ (AppData13 x) = return [x]
 packetToFragments13 _ _ ChangeCipherSpec13 = return [encodeChangeCipherSpec]
 
-updateTranscriptHash13 :: Context -> Handshake13 -> IO ByteString
-updateTranscriptHash13 ctx hs
+encodeUpdateTranscriptHash13 :: Context -> Handshake13 -> IO ByteString
+encodeUpdateTranscriptHash13 ctx hs
     | isIgnored hs = return encoded
     | otherwise = do
         let label = show $ typeOfHandshake13 hs
@@ -117,6 +134,15 @@ updateTranscriptHash13 ctx hs
   where
     encoded = encodeHandshake13 hs
 
-    isIgnored NewSessionTicket13{} = True
-    isIgnored KeyUpdate13{} = True
-    isIgnored _ = False
+updateTranscriptHash13 :: Context -> Handshake13R -> IO ()
+updateTranscriptHash13 ctx (hs, bss)
+    | isIgnored hs = return ()
+    | otherwise = do
+        let label = show $ typeOfHandshake13 hs
+        mapM_ (updateTranscriptHash ctx label) bss
+        usingHState ctx $ mapM_ addHandshakeMessage bss
+
+isIgnored :: Handshake13 -> Bool
+isIgnored NewSessionTicket13{} = True
+isIgnored KeyUpdate13{} = True
+isIgnored _ = False

--- a/tls/Network/TLS/State.hs
+++ b/tls/Network/TLS/State.hs
@@ -79,7 +79,7 @@ import Network.TLS.Extension
 import Network.TLS.Imports
 import Network.TLS.RNG
 import Network.TLS.Struct
-import Network.TLS.Types (HostName, Role (..), Ticket)
+import Network.TLS.Types (HostName, Role (..), Ticket, WireBytes)
 import Network.TLS.Wire (GetContinuation)
 
 data TLSState = TLSState
@@ -93,8 +93,10 @@ data TLSState = TLSState
       stServerCertificateChain :: Maybe CertificateChain
     , stExtensionALPN :: Bool -- RFC 7301
     , stNegotiatedProtocol :: Maybe ByteString -- ALPN protocol
-    , stHandshakeRecordCont12 :: Maybe (GetContinuation (HandshakeType, ByteString))
-    , stHandshakeRecordCont13 :: Maybe (GetContinuation (HandshakeType, ByteString))
+    , stHandshakeRecordCont12
+        :: (Maybe (GetContinuation (HandshakeType, ByteString)), WireBytes)
+    , stHandshakeRecordCont13
+        :: (Maybe (GetContinuation (HandshakeType, ByteString)), WireBytes)
     , stClientALPNSuggest :: Maybe [ByteString]
     , stClientGroupSuggest :: Maybe [Group]
     , stClientEcPointFormatSuggest :: Maybe [EcPointFormat]
@@ -136,8 +138,8 @@ newTLSState rng clientContext =
         , stServerCertificateChain = Nothing
         , stExtensionALPN = False
         , stNegotiatedProtocol = Nothing
-        , stHandshakeRecordCont12 = Nothing
-        , stHandshakeRecordCont13 = Nothing
+        , stHandshakeRecordCont12 = (Nothing, [])
+        , stHandshakeRecordCont13 = (Nothing, [])
         , stClientALPNSuggest = Nothing
         , stClientGroupSuggest = Nothing
         , stClientEcPointFormatSuggest = Nothing

--- a/tls/Network/TLS/Struct.hs
+++ b/tls/Network/TLS/Struct.hs
@@ -118,6 +118,7 @@ module Network.TLS.Struct (
     hrrRandom,
     ClientHello (..),
     ServerHello (..),
+    HandshakeR,
 ) where
 
 import Data.X509 (
@@ -231,14 +232,14 @@ instance Show ProtocolType where
 ----------------------------------------------------------------
 
 data Packet
-    = Handshake [Handshake]
+    = Handshake [Handshake] [WireBytes]
     | Alert [(AlertLevel, AlertDescription)]
     | ChangeCipherSpec
     | AppData ByteString
     deriving (Eq)
 
 instance Show Packet where
-    show (Handshake hs) = "Handshake " ++ show hs
+    show (Handshake hs _) = "Handshake " ++ show hs
     show (Alert as) = "Alert " ++ show as
     show ChangeCipherSpec = "ChangeCipherSpec"
     show (AppData bs) = "AppData " ++ showBytesHex bs
@@ -478,7 +479,7 @@ data Handshake
 
 {- FOURMOLU_DISABLE -}
 packetType :: Packet -> ProtocolType
-packetType (Handshake _)    = ProtocolType_Handshake
+packetType (Handshake _ _)  = ProtocolType_Handshake
 packetType (Alert _)        = ProtocolType_Alert
 packetType ChangeCipherSpec = ProtocolType_ChangeCipherSpec
 packetType (AppData _)      = ProtocolType_AppData
@@ -496,3 +497,5 @@ typeOfHandshake CertVerify{}       = HandshakeType_CertVerify
 typeOfHandshake Finished{}         = HandshakeType_Finished
 typeOfHandshake NewSessionTicket{} = HandshakeType_NewSessionTicket
 {- FOURMOLU_ENABLE -}
+
+type HandshakeR = (Handshake, WireBytes)

--- a/tls/Network/TLS/Struct13.hs
+++ b/tls/Network/TLS/Struct13.hs
@@ -8,6 +8,7 @@ module Network.TLS.Struct13 (
     isKeyUpdate13,
     TicketNonce (..),
     SessionIDorTicket_ (..),
+    Handshake13R,
 ) where
 
 import Network.TLS.Imports
@@ -15,7 +16,7 @@ import Network.TLS.Struct
 import Network.TLS.Types
 
 data Packet13
-    = Handshake13 [Handshake13]
+    = Handshake13 [Handshake13] [WireBytes]
     | Alert13 [(AlertLevel, AlertDescription)]
     | ChangeCipherSpec13
     | AppData13 ByteString
@@ -76,3 +77,5 @@ contentType AppData13{}        = ProtocolType_AppData
 isKeyUpdate13 :: Handshake13 -> Bool
 isKeyUpdate13 (KeyUpdate13 _) = True
 isKeyUpdate13 _ = False
+
+type Handshake13R = (Handshake13, WireBytes)

--- a/tls/Network/TLS/Types.hs
+++ b/tls/Network/TLS/Types.hs
@@ -12,6 +12,7 @@ module Network.TLS.Types (
     bigNumFromInteger,
     defaultRecordSizeLimit,
     TranscriptHash (..),
+    WireBytes,
 ) where
 
 import Network.Socket (HostName)
@@ -64,3 +65,7 @@ newtype TranscriptHash = TranscriptHash ByteString
 
 instance Show TranscriptHash where
     show (TranscriptHash bs) = showBytesHex bs
+
+----------------------------------------------------------------
+
+type WireBytes = [ByteString]


### PR DESCRIPTION
The current approach to calculate receiver's transcript hash is redundant:

- Wire format is decoded into `Handshake` data structure
- `Handshake` is encoded into wire format again to calculate transcript hash

Implementation of this approach is straightforward but awkward.
It is likely that wire format will not be reproducible in the future.
For instance, if compression is used, compression ratio cannot be reproducible perfectly.

This new approach uses wire format directly to calculate transcript hash.
It's a big change, but I would like to take it.

This passes all test cases of `cabal test` and `tlsfuzzer`.