### PR TITLE
ech-config: require network-byte-order >= 0.1.7

### DIFF
--- a/ech-config/ech-config.cabal
+++ b/ech-config/ech-config.cabal
@@ -27,7 +27,7 @@ library
         base16-bytestring,
         bytestring,
         filepath,
-        network-byte-order
+        network-byte-order >=0.1.7
 
 executable ech-gen
     main-is:            ech-gen.hs


### PR DESCRIPTION
`Network.ByteOrder.position` is not available prior to `network-byte-order-0.1.7`.

(As a Hackage trustee I made matching revisions)