### PR TITLE
expose get certificate chain function

### DIFF
--- a/tls/Network/TLS.hs
+++ b/tls/Network/TLS.hs
@@ -236,6 +236,7 @@ module Network.TLS (
     unServerRandom,
     HandshakeMode13 (..),
     getClientCertificateChain,
+    getServerCertificateChain,
 
     -- ** Negotiated
     getNegotiatedProtocol,
@@ -361,6 +362,9 @@ type Bytes = ByteString
 --   both cases of full-negotiation and resumption.
 getClientCertificateChain :: Context -> IO (Maybe CertificateChain)
 getClientCertificateChain ctx = usingState_ ctx S.getClientCertificateChain
+
+getServerCertificateChain :: Context -> IO (Maybe CertificateChain)
+getServerCertificateChain ctx = usingState_ ctx S.getServerCertificateChain
 
 -- $exceptions
 --     Since 1.8.0, this library only throws exceptions of type 'TLSException'.


### PR DESCRIPTION
Hi, I'd like to propose the addition and export of `getServerCertificateChain`, which would be useful e.g. in an integration test in which a client connects and validate server certificates. Example use:

```
...
  sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
  connect sock (addrAddress addr)

  -- Start TLS Handshake
  ctx <- contextNew sock tlsParams
  handshake ctx

  -- Extract the Server Certificate
  serverCertificate <- getServerCertificateChain ctx

  -- Assertions on serverCertificate contents...
...
```

I'm aware that there is also a callback that could be used to write into an `MVar` but that's not as pretty as this. Thanks very much, I appreciate the library, looking forward to your feedback either way.