### PR TITLE
New clientNoTickets parameter

### DIFF
--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for "tls"
 
+## Version 2.4.1
+
+* New `clientWantTicket` parameter makes it possible to opt-out of soliciting
+  session tickets from servers.
+
 ## Version 2.3.1
 
 * Using ScrubbedBytes for secrets.

--- a/tls/Network/TLS.hs
+++ b/tls/Network/TLS.hs
@@ -46,6 +46,7 @@ module Network.TLS (
     clientUseServerNameIndication,
     clientWantSessionResume,
     clientWantSessionResumeList,
+    clientWantTicket,
     clientShared,
     clientHooks,
     clientSupported,

--- a/tls/Network/TLS/Handshake/Client/ClientHello.hs
+++ b/tls/Network/TLS/Handshake/Client/ClientHello.hs
@@ -262,11 +262,12 @@ sendClientHello' cparams ctx Groups{..} crand (pskInfo, rtt0info, rtt0) = do
         Nothing -> return Nothing
         Just siz -> return $ Just $ toExtensionRaw $ RecordSizeLimit $ fromIntegral siz
 
-    sessionTicketExt = do
+    sessionTicketExt =
         case clientSessions cparams of
             (sidOrTkt, _) : _
                 | isTicket sidOrTkt -> return $ Just $ toExtensionRaw $ SessionTicket sidOrTkt
-            _ -> return $ Just $ toExtensionRaw $ SessionTicket ""
+            _   | clientWantTicket cparams -> return $ Just $ toExtensionRaw $ SessionTicket ""
+                | otherwise -> return $ Nothing
 
     earlyDataExt
         | rtt0 = return $ Just $ toExtensionRaw (EarlyDataIndication Nothing)

--- a/tls/Network/TLS/Parameters.hs
+++ b/tls/Network/TLS/Parameters.hs
@@ -153,6 +153,16 @@ data ClientParams = ClientParams
     -- specified for TLS 1.2 but only the first entry is used.
     --
     -- Default: '[]'
+    , clientWantTicket :: Bool
+    -- ^ Whether to solicit TLS 1.2 session tickets (or TLS 1.3
+    -- resumption PSKs) from servers.  With a 'False' setting,
+    -- stateless clients that never do resumption can avoid
+    -- wasting server and client resources used to generate,
+    -- transmit and process tickets that will never be used.
+    --
+    -- Default: 'True'
+    --
+    -- @since 2.4.1
     , clientShared :: Shared
     -- ^ See the default value of 'Shared'.
     , clientHooks :: ClientHooks
@@ -192,6 +202,7 @@ defaultParamsClient serverName serverId =
         , clientUseServerNameIndication = True
         , clientWantSessionResume = Nothing
         , clientWantSessionResumeList = []
+        , clientWantTicket = True
         , clientShared = def
         , clientHooks = def
         , clientSupported = def


### PR DESCRIPTION
Stateless clients that never resume sessions can opt out of soliciting tickets from servers.

Fixes: #522