### PR TITLE
Fix typos

### DIFF
--- a/ech-config/util/ech-gen.hs
+++ b/ech-config/util/ech-gen.hs
@@ -99,7 +99,7 @@ main = do
             BS.writeFile secfileP secPEM
             {-
                         let secfileN = num ++ ".nss"
-                            x = magic <> skm -- FIXME: pk is neccessary, sigh.
+                            x = magic <> skm -- FIXME: pk is necessary, sigh.
                             len = BS.length x
                             (a, b) = len `divMod` 256
                             y = BS.pack [fromIntegral a, fromIntegral b] <> x <> encodedConfigList

--- a/tls-session-manager/Network/TLS/SessionTicket.hs
+++ b/tls-session-manager/Network/TLS/SessionTicket.hs
@@ -37,7 +37,7 @@ defaultConfig :: Config
 defaultConfig =
     Config
         { ticketLifetime = 7200 -- 2 hours
-        , secretKeyInterval = 1800 -- 30 minites
+        , secretKeyInterval = 1800 -- 30 minutes
         }
 
 -- | Creating a session ticket manager.

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Version 2.4.0
 
-* Idential to v2.3.1 but major version up as v2.3.1 breaks "quic".
+* Identical to v2.3.1 but major version up as v2.3.1 breaks "quic".
 
 ## Version 2.3.1 (deprecated)
 
@@ -91,14 +91,14 @@
   This feature is automatically used if the peer supports it.
 * More tests with `tlsfuzzer` especially for client authentication
   and 0-RTT.
-* Implementing a utility funcation, `validateClientCertificate`, for
+* Implementing a utility function, `validateClientCertificate`, for
   client authentication.
 * Bug fix for echo back logic of Cookie extension.
 * More pretty show for the internal `Handshake` structure for debugging.
 
 ## Version 2.1.6
 
-* Testing with "tlsfuzzer" again. Now don't send an alert agaist to
+* Testing with "tlsfuzzer" again. Now don't send an alert against to
   peer's alert. Double locking (aka self dead-lock) is fixed. Sending
   an alert for known-but-cannot-parse extensions. Other corner cases
   are also fixed.
@@ -362,7 +362,7 @@ FEATURES:
 API CHANGES:
 
 - `SessionManager` implementations need to provide a `sessionResumeOnlyOnce`
-  function to accomodate resumption scenarios with 0-RTT data.  The function is
+  function to accommodate resumption scenarios with 0-RTT data.  The function is
   called only on the server side.
 - Data type `SessionData` is extended with four new fields for TLS version 1.3.
   `SessionManager` implementations that serializes/deserializes `SessionData`

--- a/tls/Network/TLS.hs
+++ b/tls/Network/TLS.hs
@@ -11,7 +11,7 @@
 -- protocol, and support RSA and Ephemeral (Elliptic curve and
 -- regular) Diffie Hellman key exchanges, and many extensions.
 --
--- The tipical usage is:
+-- The typical usage is:
 --
 -- > socket <- ...
 -- > ctx <- contextNew socket <params>

--- a/tls/Network/TLS/Compression.hs
+++ b/tls/Network/TLS/Compression.hs
@@ -51,7 +51,7 @@ instance Eq Compression where
     (==) c1 c2 = compressionID c1 == compressionID c2
 
 -- | intersect a list of ids commonly given by the other side with a list of compression
--- the function keeps the list of compression in order, to be able to find quickly the prefered
+-- the function keeps the list of compression in order, to be able to find quickly the preferred
 -- compression.
 compressionIntersectID :: [Compression] -> [Word8] -> [Compression]
 compressionIntersectID l ids = filter (\c -> compressionID c `elem` ids) l

--- a/tls/Network/TLS/Context/Internal.hs
+++ b/tls/Network/TLS/Context/Internal.hs
@@ -211,7 +211,7 @@ data TLS13State = TLS13State
     , tls13stClientExtensions :: [ExtensionRaw] -- client
     , tls13stChoice :: ~CipherChoice -- client
     , tls13stHsKey :: Maybe (SecretTriple HandshakeSecret) -- client
-    -- Actuall session id for TLS 1.2, random value for TLS 1.3
+    -- Actual session id for TLS 1.2, random value for TLS 1.3
     , tls13stSession :: Session
     , tls13stSentExtensions :: [ExtensionID]
     }

--- a/tls/Network/TLS/Core.hs
+++ b/tls/Network/TLS/Core.hs
@@ -188,7 +188,7 @@ sendData ctx dataToSend = liftIO $ do
         -- All chunks are protected with the same write lock because we don't
         -- want to interleave writes from other threads in the middle of our
         -- possibly large write.
-        mlen <- getPeerRecordLimit ctx -- plaintext, dont' adjust for TLS 1.3
+        mlen <- getPeerRecordLimit ctx -- plaintext, don't adjust for TLS 1.3
         mapM_ (mapChunks_ mlen sendP) (L.toChunks dataToSend)
 
 -- | Get data out of Data packet, and automatically renegotiate if a Handshake

--- a/tls/Network/TLS/Extension.hs
+++ b/tls/Network/TLS/Extension.hs
@@ -443,7 +443,7 @@ data MessageType
 ------------------------------------------------------------
 
 -- | Server Name extension including the name type and the associated name.
--- the associated name decoding is dependant of its name type.
+-- the associated name decoding is dependent of its name type.
 -- name type = 0 : hostname
 newtype ServerName = ServerName [ServerNameType] deriving (Show, Eq)
 

--- a/tls/Network/TLS/Handshake/Server.hs
+++ b/tls/Network/TLS/Handshake/Server.hs
@@ -45,9 +45,9 @@ handshakeServerWith = handshake
 -- | Put the server context in handshake mode.
 --
 -- Expect a client hello message as parameter.
--- This is useful when the client hello has been already poped from the recv layer to inspect the packet.
+-- This is useful when the client hello has been already popped from the recv layer to inspect the packet.
 --
--- When the function returns, a new handshake has been succesfully negociated.
+-- When the function returns, a new handshake has been successfully negotiated.
 -- On any error, a HandshakeFailed exception is raised.
 handshake :: ServerParams -> Context -> HandshakeR -> IO ()
 handshake sparams ctx chb@(ClientHello ch, bs) = do
@@ -66,7 +66,7 @@ handshake sparams ctx chb@(ClientHello ch, bs) = do
                 SelectKeyShareHRR g -> do
                     sendHRR ctx g r0 chI $ isJust mcrnd
                     -- Don't reset ctxEstablished since 0-RTT data
-                    -- would be comming, which should be ignored.
+                    -- would be coming, which should be ignored.
                     handshakeServer sparams ctx
                 SelectKeyShareFound cliKeyShare -> do
                     unless (checkClientKeyShareKeyLength cliKeyShare) $

--- a/tls/Network/TLS/Handshake/Server/ClientHello12.hs
+++ b/tls/Network/TLS/Handshake/Server/ClientHello12.hs
@@ -101,7 +101,7 @@ credsTriple sparams CH{..} extraCreds
 
     -- Cipher selection is performed in two steps: first server credentials
     -- are flagged as not suitable for signature if not compatible with
-    -- negotiated signature parameters.  Then ciphers are evalutated from
+    -- negotiated signature parameters.  Then ciphers are evaluated from
     -- the resulting credentials.
 
     supported = serverSupported sparams

--- a/tls/Network/TLS/Handshake/Server/ServerHello12.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello12.hs
@@ -93,7 +93,7 @@ validateSession ctx ciphers sni ems m@(Just sd)
     | TLS12 < sessionVersion sd = return Nothing -- fixme
     | CipherId (sessionCipher sd) `notElem` ciphers =
         throwCore $
-            Error_Protocol "new cipher is diffrent from the old one" IllegalParameter
+            Error_Protocol "new cipher is different from the old one" IllegalParameter
     | isJust sni && sessionClientSNI sd /= sni = do
         usingState_ ctx clearClientSNI
         return Nothing

--- a/tls/Network/TLS/Handshake/Server/TLS13.hs
+++ b/tls/Network/TLS/Handshake/Server/TLS13.hs
@@ -369,7 +369,7 @@ data KeyUpdateRequest
       TwoWay
     deriving (Eq, Show)
 
--- | Updating appication traffic secrets for TLS 1.3.
+-- | Updating application traffic secrets for TLS 1.3.
 --   If this API is called for TLS 1.3, 'True' is returned.
 --   Otherwise, 'False' is returned.
 updateKey :: MonadIO m => Context -> KeyUpdateRequest -> m Bool

--- a/tls/Network/TLS/Parameters.hs
+++ b/tls/Network/TLS/Parameters.hs
@@ -65,7 +65,7 @@ data DebugParams = DebugParams
     --
     -- Default: 'Nothing'
     , debugPrintSeed :: Seed -> IO ()
-    -- ^ Add a way to print the seed that was randomly generated. re-using the same seed
+    -- ^ Add a way to print the seed that was randomly generated. reusing the same seed
     -- will reproduce the same randomness with 'debugSeed'
     --
     -- Default: no printing
@@ -669,7 +669,7 @@ data ClientHooks = ClientHooks
     --   (3) rejecting unless 1 < dh_p && pub < dh_p - 1
     --   (4) rejecting if dh_size < 1024 (to prevent Logjam attack)
     --
-    --   See RFC 7919 section 3.1 for recommandations.
+    --   See RFC 7919 section 3.1 for recommendations.
     , onServerFinished :: Information -> IO ()
     -- ^ When a handshake is done, this hook can check `Information`.
     , onSelectKeyShareGroups :: [Group] -> [Group]
@@ -734,7 +734,7 @@ data ServerHooks = ServerHooks
     -- of the certificate.  This verification is performed by the
     -- library internally.
     --
-    -- Default: returns the followings:
+    -- Default: returns the following:
     --
     -- @
     -- CertificateUsageReject (CertificateRejectOther "no client certificates expected")
@@ -750,7 +750,7 @@ data ServerHooks = ServerHooks
     -- client version and the client list of ciphers.
     --
     -- This could be useful with old clients and as a workaround to
-    -- the BEAST (where RC4 is sometimes prefered with TLS < 1.1)
+    -- the BEAST (where RC4 is sometimes preferred with TLS < 1.1)
     --
     -- The client cipher list cannot be empty.
     --

--- a/tls/Network/TLS/QUIC.hs
+++ b/tls/Network/TLS/QUIC.hs
@@ -116,7 +116,7 @@ data QUICCallbacks = QUICCallbacks
     { quicSend :: [(CryptLevel, ByteString)] -> IO ()
     -- ^ Called by TLS so that QUIC sends one or more handshake fragments. The
     -- content transiting on this API is the plaintext of the fragments and
-    -- QUIC responsability is to encrypt this payload with the key material
+    -- QUIC responsibility is to encrypt this payload with the key material
     -- given for the specified level and an appropriate encryption scheme.
     --
     -- The size of the fragments may exceed QUIC datagram limits so QUIC may
@@ -194,7 +194,7 @@ tlsQUICClient cparams callbacks = do
         let qexts = filterQTP exts
         when (null qexts) $ do
             throwCore $
-                Error_Protocol "QUIC transport parameters are mssing" MissingExtension
+                Error_Protocol "QUIC transport parameters are missing" MissingExtension
         quicNotifyExtensions callbacks ctx qexts
         quicInstallKeys callbacks ctx (InstallApplicationKeys appSecInfo)
 
@@ -222,7 +222,7 @@ tlsQUICServer sparams callbacks = do
         let qexts = filterQTP exts
         when (null qexts) $ do
             throwCore $
-                Error_Protocol "QUIC transport parameters are mssing" MissingExtension
+                Error_Protocol "QUIC transport parameters are missing" MissingExtension
         quicNotifyExtensions callbacks ctx qexts
         quicInstallKeys callbacks ctx (InstallEarlyKeys mEarlySecInfo)
         quicInstallKeys callbacks ctx (InstallHandshakeKeys handSecInfo)

--- a/tls/test/HandshakeSpec.hs
+++ b/tls/test/HandshakeSpec.hs
@@ -1002,7 +1002,7 @@ handshake13_ee_groups (CSP13 (cli, srv)) = do
             , srv{serverSupported = svrSupported}
             )
     (_, serverMessages) <- runTLSCapture13 params
-    -- The server should tell X25519 in supported_groups in EE to clinet
+    -- The server should tell X25519 in supported_groups in EE to client
     let isSupportedGroups (ExtensionRaw eid _) = eid == EID_SupportedGroups
         eeMessagesHaveExt =
             [ any isSupportedGroups exts

--- a/tls/util/Common.hs
+++ b/tls/util/Common.hs
@@ -111,7 +111,7 @@ getInfo ctx = do
     minfo <- contextGetInformation ctx
     case minfo of
         Nothing -> do
-            putStrLn "Erro: information cannot be obtained"
+            putStrLn "Error: information cannot be obtained"
             exitFailure
         Just info -> return info
 


### PR DESCRIPTION
Found via `codespell -L ciph,siz,shouldbe,froms,onlyonce,sems,inh,fave,anull,etxt,ment,shs,appar`