### PR TITLE
fix: bound certificate decompression

### DIFF
--- a/tls/test/EncodeSpec.hs
+++ b/tls/test/EncodeSpec.hs
@@ -1,6 +1,13 @@
 module EncodeSpec where
 
+import Codec.Compression.Zlib (compress)
+import Control.Exception (bracket_, evaluate)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
+import Data.Either (isLeft)
+import Data.Int (Int64)
+import GHC.Conc (disableAllocationLimit, enableAllocationLimit, setAllocationCounter)
 import Network.TLS
 import Network.TLS.Internal
 import Test.Hspec
@@ -17,6 +24,34 @@ spec = do
             decodeHs (encodeHandshake x) `shouldBe` Right x
         prop "can encode/decode Handshake13" $ \x -> do
             decodeHs13 (encodeHandshake13 x) `shouldBe` Right x
+        it "round trips a valid TLS 1.3 compressed certificate" $ do
+            let certificate =
+                    CompressedCertificate13
+                        B.empty
+                        (CertificateChain_ $ CertificateChain [])
+                        []
+            decodeHs13 (encodeHandshake13 certificate) `shouldBe` Right certificate
+        it "rejects decompressed output shorter than its declared size" $ do
+            let plain = encodeCertificate13 B.empty (CertificateChain []) []
+                compressed = BL.toStrict $ compress $ BL.fromStrict plain
+                encoded = runPut $ do
+                    putWord16 1
+                    putWord24 (B.length plain + 1)
+                    putOpaque24 compressed
+            decodeHandshake13 HandshakeType_CompressedCertificate encoded
+                `shouldSatisfy` isLeft
+        it "bounds TLS 1.3 certificate decompression by the declared size" $ do
+            let compressed = BL.toStrict $ compress $ BL.replicate (32 * 1024 * 1024) 0
+                encoded = runPut $ do
+                    putWord16 1
+                    putWord24 1
+                    putOpaque24 compressed
+            _ <- evaluate $ B.length encoded
+            decoded <-
+                withinAllocationLimit (8 * 1024 * 1024) $
+                    evaluate $
+                        decodeHandshake13 HandshakeType_CompressedCertificate encoded
+            decoded `shouldSatisfy` isLeft
 
 decodeHs :: ByteString -> Either TLSError Handshake
 decodeHs b = verifyResult (decodeHandshake cp) $ decodeHandshakeRecord b
@@ -37,3 +72,9 @@ verifyResult fn result =
         GotError e -> error ("got error: " ++ show e)
         GotSuccessRemaining _ _ -> error "got remaining byte left"
         GotSuccess (ty, content) -> fn ty content
+
+withinAllocationLimit :: Int64 -> IO a -> IO a
+withinAllocationLimit limit =
+    bracket_
+        (setAllocationCounter limit >> enableAllocationLimit)
+        disableAllocationLimit

--- a/tls/tls.cabal
+++ b/tls/tls.cabal
@@ -235,7 +235,8 @@ test-suite spec
         ram,
         serialise,
         time-hourglass,
-        tls
+        tls,
+        zlib
 
 benchmark tls-bench
     type:             exitcode-stdio-1.0


### PR DESCRIPTION
## Summary

Prevent unbounded TLS 1.3 certificate decompression from exhausting memory.

cc @kazu-yamamoto 

## Changes

- Limit decompressed output to the declared length plus one byte.
- Reject mismatched lengths without materializing the full output.
- Cover valid, undersized, and oversized decompression cases.

## Tests

- Full test suite passes.
- Simulated a scenario where a large expansion payload crashed a `hs-tls` server with limited memory.
- The fix commit rejects the payload and remains running.