### PR TITLE
fix: bind early data to ALPN

### DIFF
--- a/tls/Network/TLS/Handshake/Server/ClientHello13.hs
+++ b/tls/Network/TLS/Handshake/Server/ClientHello13.hs
@@ -34,7 +34,8 @@ processClientHello13
     -> IO
         ( SelectKeyShareResult
         , (Cipher, Hash, Bool) -- rtt0
-        , (SecretPair EarlySecret, [ExtensionRaw], Bool, Bool) -- authenticated, is0RTTvalid
+        , (SecretPair EarlySecret, [ExtensionRaw], Bool, Bool, Maybe ByteString)
+          -- authenticated, is0RTTvalid, ticket ALPN
         )
 processClientHello13 sparams ctx ch@CH{..} = do
     when
@@ -126,14 +127,15 @@ pskAndEarlySecret
     -> Context
     -> (Cipher, Hash, Bool) -- rtt0
     -> ClientHello
-    -> IO (SecretPair EarlySecret, [ExtensionRaw], Bool, Bool) -- authenticated, is0RTTvalid
+    -> IO (SecretPair EarlySecret, [ExtensionRaw], Bool, Bool, Maybe ByteString)
+    -- authenticated, is0RTTvalid, ticket ALPN
 pskAndEarlySecret sparams ctx (usedCipher, usedHash, rtt0) CH{..} = do
-    (psk, binderInfo, is0RTTvalid) <- choosePSK
+    (psk, binderInfo, is0RTTvalid, ticketALPN) <- choosePSK
     earlyKey <- calculateEarlySecret ctx choice (Left psk)
     let earlySecret = pairBase earlyKey
         authenticated = isJust binderInfo
     preSharedKeyExt <- checkBinder earlySecret binderInfo
-    return (earlyKey, preSharedKeyExt, authenticated, is0RTTvalid)
+    return (earlyKey, preSharedKeyExt, authenticated, is0RTTvalid, ticketALPN)
   where
     choice = makeCipherChoice TLS13 usedCipher
 
@@ -142,7 +144,7 @@ pskAndEarlySecret sparams ctx (usedCipher, usedHash, rtt0) CH{..} = do
             EID_PreSharedKey
             MsgTClientHello
             chExtensions
-            (return (zero, Nothing, False))
+            (return (zero, Nothing, False, Nothing))
             selectPSK
 
     selectPSK (PreSharedKeyClientHello (PskIdentity identity obfAge : _) bnds@(bnd : _)) = do
@@ -167,12 +169,18 @@ pskAndEarlySecret sparams ctx (usedCipher, usedHash, rtt0) CH{..} = do
                         isFresh <- checkFreshness tinfo obfAge
                         (isPSKvalid, is0RTTvalid) <- checkSessionEquality sdata
                         if isPSKvalid && isFresh
-                            then return (psk, Just (bnd, 0 :: Int, len), is0RTTvalid)
+                            then
+                                return
+                                    ( psk
+                                    , Just (bnd, 0 :: Int, len)
+                                    , is0RTTvalid
+                                    , sessionALPN sdata
+                                    )
                             else -- fall back to full handshake
-                                return (zero, Nothing, False)
-                    _ -> return (zero, Nothing, False)
-            else return (zero, Nothing, False)
-    selectPSK _ = return (zero, Nothing, False)
+                                return (zero, Nothing, False, Nothing)
+                    _ -> return (zero, Nothing, False, Nothing)
+            else return (zero, Nothing, False, Nothing)
+    selectPSK _ = return (zero, Nothing, False, Nothing)
 
     checkBinder _ Nothing = return []
     checkBinder earlySecret (Just (binder, n, tlen)) = do
@@ -184,9 +192,6 @@ pskAndEarlySecret sparams ctx (usedCipher, usedHash, rtt0) CH{..} = do
 
     checkSessionEquality sdata = do
         msni <- usingState_ ctx getClientSNI
-        -- ALPN should be checked.
-        -- But it's an extension in EE, sigh.
-        --        malpn <- usingState_ ctx getNegotiatedProtocol
         let isSameSNI = sessionClientSNI sdata == msni
             isSameCipher = sessionCipher sdata == cipherID usedCipher
             ciphers = supportedCiphers $ serverSupported sparams
@@ -195,9 +200,8 @@ pskAndEarlySecret sparams ctx (usedCipher, usedHash, rtt0) CH{..} = do
                 Nothing -> False
                 Just c -> cipherHash c == cipherHash usedCipher
             isSameVersion = TLS13 == sessionVersion sdata
-            --            isSameALPN = sessionALPN sdata == malpn
             isPSKvalid = isSameKDF && isSameSNI -- fixme: SNI is not required
-            is0RTTvalid = isSameVersion && isSameCipher -- && isSameALPN
+            is0RTTvalid = isSameVersion && isSameCipher
         return (isPSKvalid, is0RTTvalid)
 
     dhModes =

--- a/tls/Network/TLS/Handshake/Server/ServerHello13.hs
+++ b/tls/Network/TLS/Handshake/Server/ServerHello13.hs
@@ -37,7 +37,8 @@ sendServerHello13
     -> Context
     -> KeyShareEntry
     -> (Cipher, Hash, Bool) -- rtt0
-    -> (SecretPair EarlySecret, [ExtensionRaw], Bool, Bool) -- authenticated, is0RTTvalid
+    -> (SecretPair EarlySecret, [ExtensionRaw], Bool, Bool, Maybe ByteString)
+    -- authenticated, is0RTTvalid, ticket ALPN
     -> ClientHello
     -> Maybe ClientRandom
     -> IO
@@ -46,7 +47,7 @@ sendServerHello13
         , Bool -- authenticated
         , Bool -- rtt0OK
         )
-sendServerHello13 sparams ctx clientKeyShare (usedCipher, usedHash, rtt0) (earlyKey, preSharedKeyExt, authenticated, is0RTTvalid) CH{..} mOuterClientRandom = do
+sendServerHello13 sparams ctx clientKeyShare (usedCipher, usedHash, rtt0) (earlyKey, preSharedKeyExt, authenticated, is0RTTvalid, ticketALPN) CH{..} mOuterClientRandom = do
     let clientEarlySecret = pairClient earlyKey
         earlySecret = pairBase earlyKey
     -- parse CompressCertificate to check if it is broken here
@@ -69,8 +70,15 @@ sendServerHello13 sparams ctx clientKeyShare (usedCipher, usedHash, rtt0) (early
         setOuterClientRandom mOuterClientRandom
     hrr <- usingState_ ctx getTLS13HRR
     alpnExt <- applicationProtocol ctx chExtensions sparams
+    negotiatedALPN <- usingState_ ctx getNegotiatedProtocol
     setServerParameter
-    let rtt0OK = authenticated && not hrr && rtt0 && rtt0accept && is0RTTvalid
+    let rtt0OK =
+            authenticated
+                && not hrr
+                && rtt0
+                && rtt0accept
+                && is0RTTvalid
+                && ticketALPN == negotiatedALPN
     extraCreds <-
         usingState_ ctx getClientSNI >>= onServerNameIndication (serverHooks sparams)
     let p = makeCredentialPredicate TLS13 chExtensions

--- a/tls/test/HandshakeSpec.hs
+++ b/tls/test/HandshakeSpec.hs
@@ -60,6 +60,8 @@ spec = do
         prop "can handshake with TLS 1.3 PSK ticket" handshake13_psk_ticket
         prop "can handshake with TLS 1.3 PSK -> HRR" handshake13_psk_fallback
         prop "can handshake with TLS 1.3 0RTT" handshake13_0rtt
+        it "rejects TLS 1.3 early data when ALPN changes" $
+            handshake13_0rtt_alpn
         prop "can handshake with TLS 1.3 0RTT -> PSK" handshake13_0rtt_fallback
         prop "can handshake with TLS 1.3 EE" handshake13_ee_groups
         prop "can handshake with TLS 1.3 EC groups" handshake13_ec
@@ -920,6 +922,67 @@ handshake13_0rtt (CSP13 (cli, srv)) = do
             params2 = (pc{clientUseEarlyData = True}, ps)
 
         runTLS0RTT params2 RTT0 earlyData
+
+handshake13_0rtt_alpn :: IO ()
+handshake13_0rtt_alpn = do
+    (cli, srv) <- generate arbitraryPairParams13
+    let cliSupported =
+            defaultSupported
+                { supportedCiphers = [cipher13_AES_128_GCM_SHA256]
+                , supportedGroups = [X25519]
+                }
+        svrSupported =
+            defaultSupported
+                { supportedCiphers = [cipher13_AES_128_GCM_SHA256]
+                , supportedGroups = [X25519]
+                , supportedGroupsTLS13 = [[X25519]]
+                }
+        cliHooks =
+            defaultClientHooks
+                { onSuggestALPN = return $ Just ["h2"]
+                }
+        svrHooks =
+            defaultServerHooks
+                { onALPNClientSuggest = Just (return . unsafeHead)
+                }
+        params0 =
+            ( cli
+                { clientSupported = cliSupported
+                , clientHooks = cliHooks
+                }
+            , srv
+                { serverSupported = svrSupported
+                , serverHooks = svrHooks
+                , serverEarlyDataSize = 2048
+                }
+            )
+    sessionRefs <- twoSessionRefs
+    let params =
+            setPairParamsSessionManagers
+                (twoSessionManagers sessionRefs)
+                params0
+    runTLSSimple13 params FullHandshake
+
+    sessionParams <- readClientSessionRef sessionRefs
+    expectJust "session param should be Just" sessionParams
+    sessionALPN (snd $ fromJust sessionParams) `shouldBe` Just "h2"
+    let (pc, ps) = setPairParamsSessionResuming (fromJust sessionParams) params
+        pc' =
+            pc
+                { clientUseEarlyData = True
+                , clientHooks =
+                    (clientHooks pc)
+                        { onSuggestALPN = return $ Just ["http/1.1"]
+                        }
+                }
+        ps' =
+            ps
+                { serverHooks =
+                    (serverHooks ps)
+                        { onALPNClientSuggest = Just (return . unsafeHead)
+                        }
+                }
+    runTLS0RTT (pc', ps') PreSharedKey "GET /admin HTTP/1.1\r\n\r\n"
 
 handshake13_0rtt_fallback :: CSP13 -> IO ()
 handshake13_0rtt_fallback (CSP13 (cli, srv)) = do


### PR DESCRIPTION
## Summary

Bind TLS 1.3 early-data acceptance to the ALPN stored in the resumed session ticket.

Previously, protocol-specific early data could cross an ALPN boundary and reach the wrong application parser, potentially bypassing protocol-specific routing, validation, or authorization assumptions.

This change ensures early data is accepted only when the resumed connection negotiates the same application protocol as the original session.

cc @kazu-yamamoto 

## Changes

- Carry the ticket’s ALPN through PSK validation.
- Compare it with the final negotiated ALPN before accepting 0-RTT.
- Reject early data on mismatch while retaining valid PSK resumption.
- Add a regression test covering `h2` tickets resumed as `http/1.1`.

## Tests

- Confirmed mismatched ALPN falls back to PSK without accepting early data.
- Confirmed matching-ALPN 0-RTT remains accepted.
- Full TLS test suite passes.